### PR TITLE
Stop handing the linker a second copy of every function

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -76,17 +76,36 @@ def files_from_delinks(delinks_txt: Path):
     return out
 
 
-def stage_delinked_objects(link_dir: Path):
-    """Copy every `.o` from build/delinks/ into build/link/ with a flat name.
+def stage_delinked_objects(link_dir: Path, compiled_names=()):
+    """Copy the `.o` files from build/delinks/ into build/link/ with flat names.
 
     dsd lcf references bare object names (no path), so mwldarm needs to find
     them via -L. Flattening avoids per-file -L flags.
+
+    A delink whose source we compile is NOT staged. Both copies carry the same
+    bare name, both were handed to mwld, and the LCF asks for that bare name --
+    so which one supplied a function came down to input order, and nothing in
+    the build recorded a choice. Every function claimed as decompiled had a
+    same-named object holding the original bytes sitting next to it in the link.
+    Staging only the delinks nothing compiles removes the ambiguity instead of
+    relying on the ordering.
     """
+    compiled_names = set(compiled_names)
+    for stale in compiled_names:
+        f = link_dir / stale
+        if f.exists():
+            f.unlink()
+    skipped = 0
     for src in (BUILD / "delinks").rglob("*.o"):
+        if src.name in compiled_names:
+            skipped += 1
+            continue
         dst = link_dir / src.name
         if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
             continue
         shutil.copyfile(src, dst)
+    if skipped:
+        print(f"[configure] staged delinks, skipped {skipped} superseded by compiled C")
 
 
 def rel(p):
@@ -273,9 +292,6 @@ def main():
         str(ROOT / "config" / "arm9" / "config.yaml"))
     add_absolute_symbols(BUILD / "arm9.lcf")
 
-    print("[configure] stage delinked .o files into build/link/")
-    stage_delinked_objects(LINK)
-
     src_files = []
     for module_dir in MODULES:
         src_files.extend(files_from_delinks(module_dir / "delinks.txt"))
@@ -283,6 +299,9 @@ def main():
     # scans (shouldn't with our layout, but be safe).
     src_files = sorted(set(src_files))
     print(f"[configure] {len(src_files)} matched source files to compile")
+
+    print("[configure] stage delinked .o files into build/link/")
+    stage_delinked_objects(LINK, {Path(s).with_suffix(".o").name for s in src_files})
 
     emit_ninja(ROOT / "build.ninja", src_files)
     print("[configure] wrote build.ninja")


### PR DESCRIPTION
Closes #8.

build/link/ held a flat copy of every delinked object, including the
ones whose function is compiled from C. Both copies carry the same bare
name, both were passed to mwld, and arm9.lcf asks for objects by bare
name. So which one supplied a function came down to the order of the
input list, and nothing in the build recorded a choice: every function
counted as decompiled had an object holding the original bytes sitting
beside it.

Nothing has gone wrong because of it, since the bytes are the same, but a
build that is correct by input ordering is one reordering away from linking
original bytes over working C and still passing every check.

configure now stages only the delinks nothing compiles, and removes a stale
copy of a compiled one left in build/link/ by an earlier run.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
