### PR TITLE
Derive the project root instead of hardcoding one machine's path

### DIFF
--- a/tools/_argprobe.py
+++ b/tools/_argprobe.py
@@ -1,11 +1,14 @@
 """Parks a +-4 = una instruccion. En vez de adivinar el argumento que falta, ALINEA
    los dos streams y LEE la constante de la instruccion que solo tiene la ROM.
    (Adivinar 0/1/-1 falla en cuanto la constante es 0x14 -- pillado por autotest.)"""
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, re, sys, glob, subprocess, difflib
 from concurrent.futures import ThreadPoolExecutor
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB
 
-ROOT = r"E:\KH 3582\decomp"
+ROOT = _ROOT
 sys.path.insert(0, os.path.join(ROOT, "tools"))
 from match import text_relocs, FLAGS
 

--- a/tools/carve_sibling.py
+++ b/tools/carve_sibling.py
@@ -14,9 +14,12 @@ refuses any command line that mentions a function other than the locked one.
 Writes build/try/g_<dst_func>.c and prints the map plus a byte-difference
 summary of the two ROM bodies, so a tuning change shows up before compiling.
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import io, json, os, sys
 
-ROOT = "E:/KH 3582/decomp"
+ROOT = _ROOT
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 
 dst, sov_arg, disp = sys.argv[1], sys.argv[2], int(sys.argv[3], 16)

--- a/tools/census_coloring.py
+++ b/tools/census_coloring.py
@@ -3,11 +3,14 @@
    y solo cambian los numeros de registro. Luego extrae la biyeccion ROM->mwcc de
    cada uno para buscar una regla.
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, re, sys, glob
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
-ROOT = r"E:\KH 3582\decomp"
+ROOT = _ROOT
 sys.path.insert(0, os.path.join(ROOT, "tools"))
 import _argprobe as P
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB

--- a/tools/dedupprop.py
+++ b/tools/dedupprop.py
@@ -10,7 +10,9 @@
 # Usage:  python dedupprop.py [--write]     (default is a dry run)
 import json, glob, os, re, subprocess, sys, collections
 
-ROOT = r"E:\KH 3582\decomp"
+import os as _os
+_ROOT = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
+ROOT = _ROOT
 WRITE = "--write" in sys.argv
 
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))

--- a/tools/donors.py
+++ b/tools/donors.py
@@ -6,9 +6,12 @@ calls: two copies of one routine in different overlays call the same shared
 helpers. Rank matched functions by how much of the pending function's external
 call set they reproduce. Usage: python build/try/donors.py ovNNN
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, re, sys
 
-ROOT = "E:/KH 3582/decomp"
+ROOT = _ROOT
 ov = sys.argv[1]
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 

--- a/tools/dsprot_decrypt.py
+++ b/tools/dsprot_decrypt.py
@@ -4,11 +4,14 @@ Fuente del algoritmo: https://github.com/taxicat1/dsprot (rama 1.10), src/rc4.c 
 src/encryptor.c. Reimplementado aqui en Python para VERIFICAR que ov028 es DS Protect;
 no se copia codigo al repo.
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import sys
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
 
 BASE = 0x0208a7e0                      # inicio de ov028 en memoria
-BIN  = r'E:\KH 3582\decomp\build\build\arm9_ov028.bin'
+BIN  = _os.path.join(_ROOT, 'build/build/arm9_ov028.bin')
 data = bytearray(open(BIN, 'rb').read())
 
 def w(off):

--- a/tools/find_dead_pred.py
+++ b/tools/find_dead_pred.py
@@ -6,10 +6,13 @@
    no tiene (mwcc reusa los flags en vez de volver a comparar). Confirmado en
    func_ov008_02077f1c y func_ov024_02084fac el 2026-07-18.
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, re, sys, glob
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB
 
-ROOT = r"E:\KH 3582\decomp"
+ROOT = _ROOT
 IDX = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 
 OPP = {"eq": "ne", "ne": "eq", "mi": "pl", "pl": "mi", "lt": "ge", "ge": "lt",

--- a/tools/romdis.py
+++ b/tools/romdis.py
@@ -5,10 +5,13 @@ hole), so read the bytes from build/func_index.json instead and annotate each
 relocated word with the symbol it resolves to.
 Usage: python build/try/dis.py <name> [start] [count]
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, sys
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB
 
-ROOT = "E:/KH 3582/decomp"
+ROOT = _ROOT
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 name = sys.argv[1]
 start = int(sys.argv[2]) if len(sys.argv) > 2 else 0

--- a/tools/survey_siblings.py
+++ b/tools/survey_siblings.py
@@ -6,9 +6,12 @@ constant offset repeated across every pending function.
 
 Usage: python build/try/survey.py ovNNN
 """
+import os as _os
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+_ROOT = _os.path.dirname(_HERE)
 import json, os, re, sys
 
-ROOT = "E:/KH 3582/decomp"
+ROOT = _ROOT
 ov = sys.argv[1]
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 


### PR DESCRIPTION
Closes #16.

Nine tools carried an absolute path to the machine they were written on,
so they raised FileNotFoundError on every other checkout. Several are
the ones that turn one solved function into several (dedupprop, donors,
carve_sibling, survey_siblings, find_dead_pred), so those were the tools
that did not run.

Each now derives the root from its own location.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
