### PR TITLE
Call the project's own interpreter, not whatever is on PATH

### DIFF
--- a/tools/audit_parks_build.py
+++ b/tools/audit_parks_build.py
@@ -22,12 +22,13 @@ import re
 import subprocess
 import sys
 
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODE = re.compile(r'kind:function\((arm|thumb)')
 
 
 def mode_of(name):
     """Look the function's instruction set up in the symbol tables, if it is there."""
-    for root, _dirs, files in os.walk('config'):
+    for root, _dirs, files in os.walk(os.path.join(ROOT, 'config')):
         for f in files:
             if f != 'symbols.txt':
                 continue
@@ -47,7 +48,7 @@ def mode_of(name):
 def main():
     verbose = '--verbose' in sys.argv
     parked = []
-    for root, _dirs, files in os.walk('src'):
+    for root, _dirs, files in os.walk(os.path.join(ROOT, 'src')):
         if 'nonmatching' not in root:
             continue
         for f in files:
@@ -59,7 +60,7 @@ def main():
         name = os.path.basename(path)[:-2]
         # try both modes: an ARM-only attempt on a THUMB function reports a size gap,
         # not a compile error, so either result proves the file builds
-        args = ['python', 'tools/verify_idx.py', path, name]
+        args = [sys.executable, os.path.join(ROOT, 'tools', 'verify_idx.py'), path, name]
         result = subprocess.run(args, capture_output=True, text=True)
         out = result.stdout + result.stderr
         if 'compilacion fallo' in out or 'Errors caused tool to abort' in out:
@@ -77,6 +78,8 @@ def main():
         if verbose:
             print('ok     %s' % path.replace(os.sep, '/'))
 
+    if not parked:
+        raise SystemExit('no nonmatching/ files found under ' + os.path.join(ROOT, 'src'))
     print('%d parked files, %d that do not compile' % (len(parked), len(broken)))
     return 1 if broken else 0
 

--- a/tools/dispdec.py
+++ b/tools/dispdec.py
@@ -1,6 +1,10 @@
-import subprocess, sys, re
+import subprocess, sys, re, os
 f = sys.argv[1]
-out = subprocess.run(['python','tools/getcand.py',f], capture_output=True, text=True).stdout
+r = subprocess.run([sys.executable, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'getcand.py'), f],
+                   capture_output=True, text=True)
+if r.returncode != 0:
+    raise SystemExit((r.stdout + r.stderr).strip())
+out = r.stdout
 dis = [l for l in out.split('\n') if l.strip().startswith('disasm:')]
 dis = dis[0][len('disasm:'):] if dis else ''
 ins = [x.strip() for x in dis.split(';')]
@@ -10,6 +14,8 @@ sw = None
 for i,x in enumerate(ins):
     if x.startswith('addls pc'):
         sw = i; break
+if sw is None:
+    raise SystemExit('no `addls pc` jump table in %s -- not a switch dispatcher' % f)
 mcmp = ins[sw-1]  # cmp rN, #M
 m = re.search(r'#(0x[0-9a-f]+|\d+)', mcmp)
 ncases = int(m.group(1),0)+1

--- a/tools/dispgen.py
+++ b/tools/dispgen.py
@@ -1,9 +1,15 @@
-import subprocess, sys, re
+import subprocess, sys, re, os
 f = sys.argv[1]
-out = subprocess.run(['python','tools/getcand.py',f], capture_output=True, text=True).stdout
+r = subprocess.run([sys.executable, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'getcand.py'), f],
+                   capture_output=True, text=True)
+if r.returncode != 0:
+    raise SystemExit((r.stdout + r.stderr).strip())
+out = r.stdout
 dis = [l for l in out.split('\n') if l.strip().startswith('disasm:')][0][len('disasm:'):]
 ins = [x.strip() for x in dis.split(';')]
-sw = next(i for i,x in enumerate(ins) if x.startswith('addls pc'))
+sw = next((i for i,x in enumerate(ins) if x.startswith('addls pc')), None)
+if sw is None:
+    raise SystemExit('// BAIL: no `addls pc` jump table in %s -- not a switch dispatcher' % f)
 ncases = int(re.search(r'#(0x[0-9a-f]+|\d+)', ins[sw-1]).group(1),0)+1
 table = ins[sw+2:sw+2+ncases]
 casetgt = [(i,int(re.search(r'#(0x[0-9a-f]+)',t).group(1),16)) for i,t in enumerate(table)]

--- a/tools/refresh_mismatches.py
+++ b/tools/refresh_mismatches.py
@@ -8,6 +8,8 @@ Usage:  python tools/refresh_mismatches.py
 
 Writes: build/known_mismatches.txt (one path per line, relative to ROOT).
 """
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +18,14 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools"))
 import audit_progress  # noqa: E402
 import diff_objs  # noqa: E402
+
+
+def ninja_exe():
+    """ninja lives in the project venv's Scripts/ here, which is not on PATH."""
+    exe = shutil.which("ninja") or shutil.which("ninja", path=os.path.dirname(sys.executable))
+    if not exe:
+        raise SystemExit("ninja not found on PATH or beside " + sys.executable)
+    return exe
 
 
 def matched_c_files():
@@ -43,11 +53,12 @@ def main():
     )
     if r.returncode != 0:
         raise SystemExit("pass-1 configure failed")
-    r = subprocess.run(["ninja", "compile"], cwd=str(ROOT), env=env)
+    r = subprocess.run([ninja_exe(), "compile"], cwd=str(ROOT), env=env)
     if r.returncode != 0:
         raise SystemExit("pass-1 compile failed")
 
     mismatches = []
+    compared = skipped = 0
     for c_path in matched_c_files():
         rel_c = c_path.relative_to(ROOT).as_posix()
         # Compiled output layout matches base_path in objdiff.json:
@@ -55,11 +66,18 @@ def main():
         compiled = ROOT / "build" / c_path.relative_to(ROOT).with_suffix(".o")
         delinked = ROOT / "build" / "delinks" / c_path.relative_to(ROOT).with_suffix(".o")
         if not compiled.exists() or not delinked.exists():
+            skipped += 1
             continue
+        compared += 1
         ok, msg = diff_objs.compare(compiled, delinked)
         if not ok:
             mismatches.append((rel_c, msg))
 
+    # A file with no compiled or delinked object was not checked, and an unchecked file goes
+    # into the link as if it matched. Say so, and refuse to write a list built from nothing.
+    print(f"compared {compared} matched files, skipped {skipped} with no compiled/delinked object")
+    if compared == 0:
+        raise SystemExit("nothing was compared; not writing known_mismatches.txt")
     body = "\n".join(path for path, _msg in sorted(mismatches)) + "\n"
     out = ROOT / "build" / "known_mismatches.txt"
     out.parent.mkdir(exist_ok=True)

--- a/tools/reloc_canon.py
+++ b/tools/reloc_canon.py
@@ -1,10 +1,14 @@
 import subprocess, sys, re, os, glob
+ROOT=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 f=sys.argv[1]
-out=subprocess.run(['python','tools/getcand.py',f],capture_output=True,text=True).stdout
+r=subprocess.run([sys.executable,os.path.join(ROOT,'tools','getcand.py'),f],capture_output=True,text=True)
+if r.returncode!=0:
+    raise SystemExit((r.stdout+r.stderr).strip())
+out=r.stdout
 # build addr->canonical name map from ALL symbols.txt
 def canon(addr):
     addr=addr.lower().lstrip('0'); pat=re.compile(r'^(\S+)\s+kind:\S+\s+addr:0x0*'+addr+r'\b')
-    for p in glob.glob('config/arm9/**/symbols.txt', recursive=True):
+    for p in glob.glob(os.path.join(ROOT,'config','arm9','**','symbols.txt'), recursive=True):
         for line in open(p):
             m=pat.match(line)
             if m: return m.group(1)


### PR DESCRIPTION
Closes #18.

Five tools shelled out to a bare python or ninja. This project keeps
both in a local environment under build/venv, so those calls failed on
this machine. refresh_mismatches died on it partway through a full-tree
run.

They now use the interpreter already running them, and resolve ninja
beside it. dispgen and dispdec also relayed a confusing IndexError when
handed a function with no jump table; they now say that is what
happened.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
