### PR TITLE
Several tools report success after reading nothing

### DIFF
--- a/tools/_argprobe.py
+++ b/tools/_argprobe.py
@@ -158,7 +158,12 @@ def work(case):
 
 
 if __name__ == "__main__":
-    triage = json.load(open(os.path.join(ROOT, "build", "sweep", "triage", "triage.json")))
+    tri = os.path.join(ROOT, "build", "sweep", "triage", "triage.json")
+    if not os.path.exists(tri):
+        raise SystemExit("missing build/sweep/triage/triage.json, and no tool in tools/ writes it any more; "
+                         "the +-4 probe cannot run standalone. rank_parks.py and census_coloring.py "
+                         "still import this module and do not need that file.")
+    triage = json.load(open(tri))
     cases = [(r[0], r[1], r[4], r[3]) for r in triage
              if r[2] == "size" and abs(r[3]) == 4 and os.path.exists(r[1])]
     print("parks a +-4:", len(cases))

--- a/tools/audit_arity.py
+++ b/tools/audit_arity.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CALL_RE = re.compile(r'\b(func_[0-9a-fA-F]{8}|func_ov\d+_[0-9a-fA-F]{8})\s*\(([^;{]*?)\)\s*;')
 EXTERN_RE = re.compile(
     r'extern\s+[\w \*]+?\b(func_[0-9a-fA-F]{8}|func_ov\d+_[0-9a-fA-F]{8})\s*\(([^)]*)\)\s*;')
@@ -54,7 +55,7 @@ def main():
     # arity actually used at call sites in MATCHED code only
     used = collections.defaultdict(collections.Counter)
     parked = []
-    for root, _dirs, files in os.walk('src'):
+    for root, _dirs, files in os.walk(os.path.join(ROOT, 'src')):
         is_parked = 'nonmatching' in root
         is_stub = 'asm_stubs' in root
         for f in files:

--- a/tools/audit_unnamed.py
+++ b/tools/audit_unnamed.py
@@ -19,6 +19,7 @@ import sys
 import urllib.parse
 from collections import Counter
 
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PORT = 8089
 
 # `FUN_` is not the only way to have no name. `ov000_helper_4d354` passes a startswith('FUN_')
@@ -67,7 +68,7 @@ def ghidra_names():
 def matched_c():
     """func name -> path, for real byte-exact C only."""
     out = {}
-    for root, _dirs, files in os.walk('src'):
+    for root, _dirs, files in os.walk(os.path.join(ROOT, 'src')):
         if 'nonmatching' in root or 'asm_stubs' in root:
             continue
         for f in files:

--- a/tools/auto_trivial.py
+++ b/tools/auto_trivial.py
@@ -6,8 +6,14 @@ import json, re, subprocess, os
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CANDS = os.path.join(ROOT, "build", "candidates.json")
+if not os.path.exists(CANDS):
+    raise SystemExit("missing build/candidates.json: tools/find_candidates.py produced it from asm/, which no "
+                     "longer exists, and this tool writes every result to a flat src/auto/ that predates "
+                     "the per-overlay tree. Nothing feeds it any more; list reloc-free functions from "
+                     "build/func_index.json instead (tools/getcand.py shows one).")
 AUTO = os.path.join(ROOT, "src", "auto"); os.makedirs(AUTO, exist_ok=True)
-cands = json.load(open(os.path.join(ROOT, "build", "candidates.json")))
+cands = json.load(open(CANDS))
 DH = {c["name"]: c for c in cands}
 md_a = Cs(CS_ARCH_ARM, CS_MODE_ARM); md_t = Cs(CS_ARCH_ARM, CS_MODE_THUMB)
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -19,6 +19,9 @@ if not AS or not os.path.exists(AS):
     AS = c[0] if c else "arm-none-eabi-as"
 MWCC = os.path.join(ROOT, "tools", "mwccarm", "3.0_patch4", "mwccarm.exe")
 LIC  = os.path.join(ROOT, "tools", "mwccarm", "license.dat")
+if not os.path.isdir(ASM):
+    raise SystemExit("asm/ does not exist: this harness assembled the pre-dsd .s files and is superseded "
+                     "by the ninja build (tools/configure.py, then ninja build/arm9.elf).")
 os.makedirs(OBJ, exist_ok=True)
 verbose = "--verbose" in sys.argv
 

--- a/tools/census_coloring.py
+++ b/tools/census_coloring.py
@@ -64,7 +64,10 @@ def analyse(case):
             {k: list(v)[0] for k, v in sorted(mapping.items()) if list(v)[0] != k})
 
 
-rank = json.load(open(os.path.join(ROOT, "build", "try", "rank.json")))
+RANK = os.path.join(ROOT, "build", "try", "rank.json")
+if not os.path.exists(RANK):
+    raise SystemExit("missing build/try/rank.json -- run tools/rank_parks.py first, it writes that file.")
+rank = json.load(open(RANK))
 cases = [(x[0], x[1], x[2]) for x in rank if os.path.exists(x[1])]
 print("parks a examinar:", len(cases))
 hits = []

--- a/tools/dedup_apply.py
+++ b/tools/dedup_apply.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """Para cada funcion ya decompilada, genera el .c de sus DUPLICADAS idenitcas
    (mismo codigo+relocs, otro nombre) y lo verifica byte-exacto. Aceleracion gratis."""
-import json, os, glob, re, subprocess
+import json, os, glob, re, subprocess, sys
 from collections import defaultdict
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+raise SystemExit("dedup_apply.py is superseded by tools/dedupprop.py: this one only scans the flat src/auto "
+                 "and src/calls directories, so on the per-overlay tree it reports 0 new functions while "
+                 "doing nothing, and it writes into src/ unconditionally. Run dedupprop.py (dry run by "
+                 "default, --write to apply).")
 idx = json.load(open(os.path.join(ROOT, "build", "func_index.json")))
 
 # grupos de identicas
@@ -24,9 +28,9 @@ def verify(name, cf, kind):
     d = idx[name]
     if d["relocs"]:
         delink = os.path.join(ROOT, "build", "delinks", d["module"] + ".o")
-        a = ["python", os.path.join(ROOT, "tools", "match.py"), cf, "--obj", delink, "--func", name]
+        a = [sys.executable, os.path.join(ROOT, "tools", "match.py"), cf, "--obj", delink, "--func", name]
     else:
-        a = ["python", os.path.join(ROOT, "tools", "match.py"), cf, d["hex"]]
+        a = [sys.executable, os.path.join(ROOT, "tools", "match.py"), cf, d["hex"]]
     return ">>> MATCH <<<" in subprocess.run(a, capture_output=True, text=True).stdout
 
 done = done_set()

--- a/tools/dedupprop.py
+++ b/tools/dedupprop.py
@@ -113,7 +113,7 @@ def verify(path, name, thumb):
     except Exception:
         return False
 
-matched, failed, rescued = [], [], []
+matched, failed, rescued, would_try = [], [], [], []
 for rep, twin in cands:
     src = open(done[rep], encoding="utf-8", errors="replace").read()
     new = subst(src, rep, twin)
@@ -134,6 +134,7 @@ for rep, twin in cands:
         continue
     tag = "  (rescues a nonmatching/)" if twin in attempted else ""
     if not WRITE:
+        would_try.append(twin)
         print("  would try %-26s <- %s%s" % (twin, rep, tag))
         continue
     open(path, "w", encoding="utf-8", newline="\n").write(new)
@@ -151,6 +152,12 @@ for rep, twin in cands:
         failed.append((twin, rep))
 
 print()
-print("matched=%d  failed=%d  rescued-from-nonmatching=%d" % (len(matched), len(failed), len(rescued)))
+if not WRITE:
+    print("DRY RUN: nothing was tried. %d candidate(s) would be attempted."
+          % len(would_try))
+    print("Re-run with --write to actually propagate and verify them.")
+else:
+    print("matched=%d  failed=%d  rescued-from-nonmatching=%d"
+          % (len(matched), len(failed), len(rescued)))
 for t in rescued:
     print("  retired nonmatching/%s.c" % t)

--- a/tools/find_calls.py
+++ b/tools/find_calls.py
@@ -7,6 +7,11 @@ from elftools.elf.elffile import ELFFile
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ASM = os.path.join(ROOT, "asm"); DELINK = os.path.join(ROOT, "build", "delinks")
 
+if not os.path.isdir(ASM):
+    raise SystemExit("asm/ does not exist: the .s files this tool parsed were replaced by dsd delinks, "
+                     "so build/calls.json can no longer be produced. build/func_index.json holds "
+                     "the same data for every function -- use tools/getcand.py <name>.")
+
 def func_syms(o_path):
     out = {}
     try: elf = ELFFile(open(o_path, "rb"))

--- a/tools/find_candidates.py
+++ b/tools/find_candidates.py
@@ -8,6 +8,11 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ASM = os.path.join(ROOT, "asm")
 DELINK = os.path.join(ROOT, "build", "delinks")
 
+if not os.path.isdir(ASM):
+    raise SystemExit("asm/ does not exist: the .s files this tool parsed were replaced by dsd delinks, "
+                     "so build/candidates.json can no longer be produced. build/func_index.json holds "
+                     "the same data for every function -- use tools/getcand.py <name>.")
+
 def func_bytes(o_path):
     out = {}
     try: elf = ELFFile(open(o_path, "rb"))

--- a/tools/getcand.py
+++ b/tools/getcand.py
@@ -1,55 +1,63 @@
 #!/usr/bin/env python3
-"""Imprime los datos de una funcion para un agente decompilador.
-   Prioridad: calls.json / candidates.json (curadas, disasm con simbolos) ->
-   func_index.json (cualquier funcion del juego)."""
-import json, sys, os
+"""Print what a decompiler needs for one function: mode, disassembly, relocations,
+   where the .c goes and the exact verify command.
+
+       python tools/getcand.py <func_name>
+
+   Source of truth is build/func_index.json: hex + relocs + mode + module for every
+   function, finished or not. The curated build/calls.json / build/candidates.json
+   lists this tool used to prefer are no longer produced (they were derived from
+   asm/, which the dsd delinks replaced) and carried nothing the index does not.
+
+   Output format is parsed by dispgen.py, dispdec.py and reloc_canon.py: keep the
+   `disasm:` line and the `+0x<off> -> <sym>` reloc lines stable.
+"""
+import json, os, sys
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-name = sys.argv[1]
+INDEX = os.path.join(ROOT, "build", "func_index.json")
 
-def load(p):
-    fp = os.path.join(ROOT, "build", p)
-    return json.load(open(fp)) if os.path.exists(fp) else {}
-calls = {c["name"]: c for c in load("calls.json")} if isinstance(load("calls.json"), list) else {}
-cands = {c["name"]: c for c in load("candidates.json")} if isinstance(load("candidates.json"), list) else {}
-index = load("func_index.json")
 
-def disasm(hexs, mode):
-    md = Cs(CS_ARCH_ARM, CS_MODE_THUMB if mode == "thumb" else CS_MODE_ARM)
-    return " ; ".join(i.mnemonic + " " + i.op_str for i in md.disasm(bytes.fromhex(hexs), 0))
+def src_dir(module, kind):
+    """main/itcm functions live flat under src/<kind>/, overlays under src/overlays/ovNNN/<kind>/."""
+    if module.startswith("ov"):
+        return "src/overlays/%s/%s" % (module, kind)
+    return "src/%s" % kind
 
-if name in calls:
-    c = calls[name]; thumb = " --thumb" if c["mode"] == "thumb" else ""
-    print("name:", name); print("mode:", c["mode"]); print("kind: HAS CALLS (reloc-aware)")
-    print("disasm:", c["asm"]); print("callees:", c["callees"])
-    print("write_to: E:/KH 3582/decomp/src/calls/%s.c" % name)
-    print('verify_cmd: python "E:/KH 3582/decomp/tools/match.py" "E:/KH 3582/decomp/src/calls/%s.c" --obj "%s" --func %s%s'
-          % (name, c["delink"].replace("\\", "/"), name, thumb))
-elif name in cands:
-    c = cands[name]; thumb = " --thumb" if c["mode"] == "thumb" else ""
-    print("name:", name); print("mode:", c["mode"]); print("kind: reloc-free")
-    print("disasm:", disasm(c["hex"], c["mode"]))
-    print("write_to: E:/KH 3582/decomp/src/auto/%s.c" % name)
-    print('verify_cmd: python "E:/KH 3582/decomp/tools/match.py" "E:/KH 3582/decomp/src/auto/%s.c" %s%s'
-          % (name, c["hex"], thumb))
-elif name in index:
-    d = index[name]; thumb = " --thumb" if d["mode"] == "thumb" else ""
-    has_calls = bool(d["relocs"])
-    kind = "calls" if has_calls else "auto"
-    print("name:", name); print("mode:", d["mode"])
-    print("kind:", "HAS CALLS (reloc-aware)" if has_calls else "reloc-free")
-    print("disasm:", disasm(d["hex"], d["mode"]))
-    if has_calls:
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__)
+    name = sys.argv[1]
+    if not os.path.exists(INDEX):
+        raise SystemExit("missing build/func_index.json -- produce it with tools/rebuild_index.py --write")
+    d = json.load(open(INDEX)).get(name)
+    if d is None:
+        raise SystemExit("not in build/func_index.json: " + name)
+    thumb = d["mode"] == "thumb"
+    md = Cs(CS_ARCH_ARM, CS_MODE_THUMB if thumb else CS_MODE_ARM)
+    disasm = " ; ".join(i.mnemonic + " " + i.op_str for i in md.disasm(bytes.fromhex(d["hex"]), 0))
+    if not disasm:
+        disasm = "(capstone decoded nothing as %s -- the mode recorded in the index is suspect)" % d["mode"]
+    kind = "calls" if d["relocs"] else "auto"
+    cpath = "%s/%s.c" % (src_dir(d["module"], kind), name)
+    py = os.path.relpath(sys.executable, ROOT).replace(os.sep, "/")
+    print("name:", name)
+    print("mode:", d["mode"])
+    print("module:", d["module"])
+    print("size:", d["size"])
+    print("kind:", "HAS CALLS (reloc-aware)" if d["relocs"] else "reloc-free")
+    print("disasm:", disasm)
+    if d["relocs"]:
         print("relocations (offset -> symbol, i.e. your callees/data refs):")
         for off, sym in d["relocs"]:
             print("    +0x%x -> %s" % (off, sym))
         print("callees:", sorted(set(s for _, s in d["relocs"])))
-        print("write_to: E:/KH 3582/decomp/src/calls/%s.c" % name)
-        print('verify_cmd: python "E:/KH 3582/decomp/tools/match.py" "E:/KH 3582/decomp/src/calls/%s.c" --obj "%s" --func %s%s'
-              % (name, os.path.join(ROOT, "build", "delinks", d["module"] + ".o").replace("\\", "/"), name, thumb))
-    else:
-        print("write_to: E:/KH 3582/decomp/src/auto/%s.c" % name)
-        print('verify_cmd: python "E:/KH 3582/decomp/tools/match.py" "E:/KH 3582/decomp/src/auto/%s.c" %s%s'
-              % (name, d["hex"], thumb))
-else:
-    print("desconocida:", name)
+    print("write_to:", cpath)
+    print('verify_cmd: %s tools/verify_idx.py "%s" %s%s'
+          % (py, cpath, name, " --thumb" if thumb else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/index_data.py
+++ b/tools/index_data.py
@@ -22,6 +22,7 @@ import glob
 import json
 import os
 import re
+import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DELINK = os.path.join(ROOT, "build", "delinks")
@@ -116,7 +117,8 @@ def collect(o_path, variants):
 
     try:
         elf = ELFFile(open(o_path, "rb"))
-    except Exception:
+    except Exception as exc:
+        print("index_data: cannot read %s: %s" % (o_path, exc), file=sys.stderr)
         return
     module = module_of(os.path.splitext(os.path.basename(o_path))[0])
 

--- a/tools/index_funcs.py
+++ b/tools/index_funcs.py
@@ -8,6 +8,12 @@ from elftools.elf.elffile import ELFFile
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DELINK = os.path.join(ROOT, "build", "delinks")
 
+raise SystemExit("index_funcs.py is superseded by tools/rebuild_index.py. Delinks now live nested under "
+                 "build/delinks/src/... and the only flat objects are _dsd_gap@<unit>_<n>.o, whose "
+                 "basename this script would record as the function's module; and it can never index "
+                 "a function that already has a .c. rebuild_index.py indexes all of them from the ROM "
+                 "and the dsd config (dry run by default, --write to merge).")
+
 # ARM/THUMB per function, from the dsd config -- the authority.
 #
 # The obvious source is the ELF convention (low bit of st_value set = THUMB), and that is what

--- a/tools/next_batch.py
+++ b/tools/next_batch.py
@@ -12,7 +12,12 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 N = int(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1].isdigit() else 18
 verbose = "-v" in sys.argv
 
-calls = json.load(open(os.path.join(ROOT, "build", "calls.json")))
+CALLS = os.path.join(ROOT, "build", "calls.json")
+if not os.path.exists(CALLS):
+    raise SystemExit("missing build/calls.json: tools/find_calls.py produced it from asm/, which no longer "
+                     "exists, and this tool only knows the flat src/calls/ layout. Nothing feeds it any more; "
+                     "build/func_index.json is the function list now (tools/getcand.py shows one).")
+calls = json.load(open(CALLS))
 done = set(os.path.splitext(f)[0] for f in os.listdir(os.path.join(ROOT, "src", "calls"))
            if f.endswith(".c"))
 done.add("func_020036a0")  # hand-asm wrapper, saltada


### PR DESCRIPTION
Closes #20.

### Make tools with dead inputs fail loudly instead of quietly

Several tools depended on asm/, build/calls.json or build/candidates.json, none
of which this project produces any more. They did not crash: find_candidates and
find_calls globbed nothing, printed a count of zero, exited zero and overwrote
their output with an empty list. build.py printed 0 OK / 0 BAD. A tool that
cannot work now says so in one line and exits non-zero.

getcand.py was worse than dead: it ran, but pointed at a delinked object path
that no longer exists, put overlay functions in src/calls/, and invoked an
interpreter that is not on PATH here. It now reads build/func_index.json, which
holds the same data for every function, and prints the real destination and a
working verify command. An unknown name is an error rather than a shrug.

### Stop tools reporting success when they examined nothing

Same fault in several places, and it is the one that has cost this project most.

refresh_mismatches skipped any file with no compiled or delinked object without
counting it, and an unexamined file then enters the link as though it matched. It
now reports how many it compared and how many it skipped, and refuses to write the
exclusion list at all if it compared none.

Three audits walked a relative path, so from any directory but the root they
reported zero files scanned and exited happily. index_data swallowed unreadable
objects silently, dropping them from the data index without a word. It now
names the object on stderr.

_argprobe and census_coloring explain what input they are missing rather than
raising.

### Say "dry run, nothing tried" instead of "matched=0"

A dry run listed 63 candidates and then printed matched=0, which reads
as "no work available" rather than "a dry run tries nothing". Read that
way, 62 free functions sat unclaimed. It now names the count it would
attempt and how to run it for real.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
