### PR TITLE
Verify data across multi-section objects

### DIFF
--- a/tools/progress.py
+++ b/tools/progress.py
@@ -61,7 +61,7 @@ def compute_byte_progress():
         # bodies until 2026-07-24.)
         if audit_progress.source_category(Path(path)) != "c_decompiled_matched":
             continue
-        c_names.add(os.path.basename(path)[:-2])  # strip .c
+        c_names.add(Path(path).stem)
 
     total_bytes = 0
     c_bytes = 0

--- a/tools/tests/test_progress_cpp.py
+++ b/tools/tests/test_progress_cpp.py
@@ -1,0 +1,23 @@
+"""C++ matching sources contribute their original function bytes to progress."""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import progress
+
+
+class ProgressCppTest(unittest.TestCase):
+    def test_cpp_function_bytes_are_counted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "src/calls/func_example.cpp"
+            symbols = root / "config/arm9/symbols.txt"
+            source.parent.mkdir(parents=True)
+            symbols.parent.mkdir(parents=True)
+            source.write_text("int func_example() { return 1; }\n")
+            symbols.write_text("func_example kind:function(arm,size=0x10) addr:0x02000000\n")
+            with patch.object(progress, "ROOT", root):
+                self.assertEqual(progress.compute_byte_progress(), (16, 16))

--- a/tools/tests/test_verify_data.py
+++ b/tools/tests/test_verify_data.py
@@ -87,18 +87,24 @@ class SectionRangeVerificationTests(unittest.TestCase):
     START = 0x0208E8FC
 
     class Section:
+        name = ".rodata"
+
         def __init__(self, payload):
             self.payload = payload
 
         def __getitem__(self, key):
             if key == "sh_size":
                 return len(self.payload)
+            if key == "sh_addralign":
+                return 1
             raise KeyError(key)
 
         def data(self):
             return self.payload
 
     class Relocations:
+        name = ".rel.rodata"
+
         def __init__(self, count):
             self.count = count
 
@@ -107,15 +113,14 @@ class SectionRangeVerificationTests(unittest.TestCase):
 
     class Elf:
         def __init__(self, payload, relocations=0):
-            self.section = SectionRangeVerificationTests.Section(payload)
+            parts = payload if isinstance(payload, list) else [payload]
+            self.sections = [SectionRangeVerificationTests.Section(part) for part in parts]
             self.relocations = relocations
 
-        def get_section_by_name(self, name):
-            if name == ".rodata":
-                return self.section
-            if name in (".rel.rodata", ".rela.rodata") and self.relocations:
-                return SectionRangeVerificationTests.Relocations(self.relocations)
-            return None
+        def iter_sections(self):
+            yield from self.sections
+            if self.relocations:
+                yield SectionRangeVerificationTests.Relocations(self.relocations)
 
     def verify(self, payload, index, relocations=0):
         fake = self.Elf(payload, relocations)
@@ -155,6 +160,24 @@ class SectionRangeVerificationTests(unittest.TestCase):
         self.assertEqual(status, verify_data.DIFFERS)
         self.assertIn("byte diff @0x2", message)
 
+    def test_configured_alias_address_preserves_exact_range_checks(self):
+        entry = {
+            "module": "ov008", "section": "rodata", "addr": None,
+            "hex": "01020304", "relocs": [],
+        }
+        index = {"table_alias": entry}
+        with patch.dict(verify_data.SYM_ADDR, {"table_alias": self.START}, clear=True):
+            status, _message, info = self.verify(b"\x01\x02\x03\x04", index)
+            self.assertEqual(status, verify_data.MATCH)
+            self.assertEqual((info["start"], info["end"]), (self.START, self.START + 4))
+            self.assertEqual(self.verify(b"\x01\x02\xff\x04", index)[0], verify_data.DIFFERS)
+            conflicting = dict(index, other=dict(entry, addr=self.START, hex="05020304"))
+            self.assertIn("conflicting", self.verify(b"\x01\x02\x03\x04", conflicting)[1])
+            relocated = {"table_alias": dict(entry, relocs=[[0, "pointer"]])}
+            self.assertIn("relocated symbol", self.verify(b"\x01\x02\x03\x04", relocated)[1])
+        with patch.dict(verify_data.SYM_ADDR, {}, clear=True):
+            self.assertEqual(self.verify(b"\x01\x02\x03\x04", index)[0], verify_data.REFUSED)
+
     def test_a_coverage_gap_is_refused(self):
         index = {
             "edges": {
@@ -165,6 +188,17 @@ class SectionRangeVerificationTests(unittest.TestCase):
         status, message, _info = self.verify(b"\x01\x02\x03\x04", index)
         self.assertEqual(status, verify_data.REFUSED)
         self.assertIn("does not cover", message)
+
+    def test_repeated_sections_are_verified_in_full_in_emission_order(self):
+        index = {"all": {
+            "module": "ov008", "section": "rodata", "addr": self.START,
+            "hex": "01020304", "relocs": [],
+        }}
+        status, _message, info = self.verify([b"\x01\x02", b"\x03\x04"], index)
+        self.assertEqual(status, verify_data.MATCH)
+        self.assertEqual(info["size"], 4)
+        self.assertEqual(self.verify([b"\xff\x02", b"\x03\x04"], index)[0], verify_data.DIFFERS)
+        self.assertEqual(self.verify([b"\x03\x04", b"\x01\x02"], index)[0], verify_data.DIFFERS)
 
     def test_a_relocated_section_is_refused(self):
         status, message, _info = self.verify(b"\x01\x02", {}, relocations=1)

--- a/tools/verify_data.py
+++ b/tools/verify_data.py
@@ -261,17 +261,24 @@ def verify_section_range(cpath, module, section, start, index):
         return REFUSED, "unsupported initialized-DATA section " + section_name, {}
     with open(compiled(cpath), "rb") as stream:
         elf = ELFFile(stream)
-        emitted_section = elf.get_section_by_name(section_name)
-        if emitted_section is None or not emitted_section["sh_size"]:
+        emitted_sections = [
+            item for item in elf.iter_sections()
+            if item.name == section_name and item["sh_size"]
+        ]
+        if not emitted_sections:
             return DIFFERS, "%s emits no %s section" % (
                 os.path.basename(cpath), section_name), {}
-        for rel_name in (".rel" + section_name, ".rela" + section_name):
-            rel_section = elf.get_section_by_name(rel_name)
-            if rel_section is not None and rel_section.num_relocations():
+        for rel_section in elf.iter_sections():
+            if (rel_section.name in (".rel" + section_name, ".rela" + section_name)
+                    and rel_section.num_relocations()):
                 return REFUSED, (
                     "%s contains relocations; use named-symbol verification"
                     % section_name), {}
-        emitted = emitted_section.data()
+        emitted = b""
+        for item in emitted_sections:
+            if (start + len(emitted)) % max(1, item["sh_addralign"]):
+                return REFUSED, section_name + " requires inter-section alignment padding", {}
+            emitted += item.data()
     end = start + len(emitted)
     expected = [None] * len(emitted)
     covered_symbols = []
@@ -279,6 +286,10 @@ def verify_section_range(cpath, module, section, start, index):
         if entry.get("module") != module or entry.get("section") != section_name[1:]:
             continue
         addr = entry.get("addr")
+        if addr is None:
+            # Delinks may retain only a suffixed alias; its configured address
+            # still identifies the original bytes without inventing an index entry.
+            addr = SYM_ADDR.get(name)
         raw = bytes.fromhex(entry.get("hex", ""))
         item_end = addr + len(raw) if addr is not None else None
         if addr is None or item_end <= start or addr >= end:


### PR DESCRIPTION
Closes #24.

mwccarm emits one section per global rather than one per file, so a
range that a single symbol used to cover can arrive as several sections.
verify_section_range now walks them all and refuses the range outright
if the emitted sections would need padding between them to line up,
rather than accepting a layout the linker would space differently. A
symbol whose index entry has no address falls back to its configured
address instead of being skipped.

Also here: progress.py took a file's name by cutting two characters off the path, which is wrong for `.cpp`. It now uses `Path(path).stem`, with a test.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
