### PR TITLE
Disassemble past literal pools in the middle of a function in poolmap

### DIFF
--- a/tools/poolmap.py
+++ b/tools/poolmap.py
@@ -20,6 +20,11 @@ import os
 import re
 import sys
 
+try:
+    sys.stdout.reconfigure(errors="replace")  # Windows console (cp1252) can't encode e.g. U+26A0; never let output encoding crash a run
+except Exception:
+    pass
+
 from capstone import CS_ARCH_ARM, CS_MODE_ARM, CS_MODE_THUMB, Cs
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -55,6 +60,11 @@ def main():
     mode, addr = sym_info(name)
     thumb = mode == "thumb"
     md = Cs(CS_ARCH_ARM, CS_MODE_THUMB if thumb else CS_MODE_ARM)
+    md.skipdata = True  # a literal pool word embedded mid-function is not a valid
+    # instruction; without this capstone's disasm() silently STOPS at the first one
+    # instead of skipping it, truncating the listing for any function with an
+    # interleaved (not just trailing) pool -- found 2026-09-11 on a 4724-byte function
+    # where the listing quietly cut off after 480 bytes with no error or warning.
     rel = {o: s for o, s in e["relocs"]}
     code = bytes.fromhex(e["hex"])
     if addr is None:


### PR DESCRIPTION
Closes #26.

capstone's disasm() stops at the first word that does not decode, so any
function with a literal pool between two runs of code was listed only up to
that pool, with no error. skipdata steps over it. On a 4,724-byte function
the listing had been cutting off after 480 bytes.

Also replace characters the Windows console cannot encode instead of
raising mid-run.

## Verification

My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM. This change does not alter compiler output.
