### PR TITLE
Decompile 4 functions in ov008

### DIFF
--- a/config/arm9/overlays/ov008/delinks.txt
+++ b/config/arm9/overlays/ov008/delinks.txt
@@ -2161,6 +2161,10 @@ src/overlays/ov008/calls/func_ov008_02067db0.c:
     complete
     .text       start:0x02067db0 end:0x02067edc
 
+src/overlays/ov008/calls/func_ov008_02067edc.c:
+    complete
+    .text       start:0x02067edc end:0x02068120
+
 src/overlays/ov008/calls/func_ov008_02068120.c:
     complete
     .text       start:0x02068120 end:0x020681b0
@@ -2168,6 +2172,10 @@ src/overlays/ov008/calls/func_ov008_02068120.c:
 src/overlays/ov008/calls/func_ov008_020681b0.c:
     complete
     .text       start:0x020681b0 end:0x0206821c
+
+src/overlays/ov008/calls/func_ov008_0206821c.c:
+    complete
+    .text       start:0x0206821c end:0x0206836c
 
 src/overlays/ov008/calls/func_ov008_0206836c.c:
     complete
@@ -2205,9 +2213,17 @@ src/overlays/ov008/calls/func_ov008_02068e68.c:
     complete
     .text       start:0x02068e68 end:0x02069180
 
+src/overlays/ov008/calls/func_ov008_02069180.c:
+    complete
+    .text       start:0x02069180 end:0x02069224
+
 src/overlays/ov008/calls/func_ov008_02069320.c:
     complete
     .text       start:0x02069320 end:0x020693c4
+
+src/overlays/ov008/calls/func_ov008_020697a4.c:
+    complete
+    .text       start:0x020697a4 end:0x020698ec
 
 src/calls/WM_EndKeySharing_0x020698ec.c:
     complete

--- a/src/overlays/ov008/calls/func_ov008_02067edc.c
+++ b/src/overlays/ov008/calls/func_ov008_02067edc.c
@@ -1,0 +1,115 @@
+typedef unsigned char u8;
+typedef unsigned int  u32;
+
+typedef struct Ov009Pair {
+    int x;
+    int y;
+} Ov009Pair;
+
+typedef struct Ov009PageContext {
+    int pageIndex;
+    int fallbackPage;
+    int activeState;
+    u8 pad_00c[0x68 - 0x0c];
+    Ov009Pair cellOffset[3][8];
+    Ov009Pair pageTarget[3];
+    Ov009Pair pageCurrent[3];
+} Ov009PageContext;
+
+typedef struct Ov009ObjectConfig {
+    int resource;
+    int field_04;
+    int field_08;
+    int field_0c;
+} Ov009ObjectConfig;
+
+extern const Ov009ObjectConfig data_ov008_0208f500;
+extern const char data_ov008_020904d0[];
+extern const int data_ov008_0208f588[3][8];
+extern void WM_EndKeySharing_0x020698ec(void);
+
+extern int         func_ov008_02050f84(int index);
+extern int         func_ov008_02050c54(void);
+extern void        func_ov008_02054744(int object,
+                                      const Ov009ObjectConfig *config);
+extern void        func_ov008_02054678(int object, const void *resource,
+                                      int value);
+extern void        func_ov008_0205477c(int object, int value);
+extern void        func_020327e0(int object, int value);
+extern void        G2x_SetBlendAlpha_(volatile void *reg, int firstTarget,
+                                     int secondTarget, int eva, int evb);
+extern int        *func_ov008_02054788(int object, int id);
+extern void        func_ov008_02054c08(int object, int *entry);
+extern Ov009Pair  *func_ov008_02054820(int object, int *entry);
+extern void        func_ov008_02054858(int object, int *entry,
+                                      const Ov009Pair *position);
+extern void        func_ov008_02054d90(int object, int *entry, int value);
+extern void        func_ov008_02068d58(int enabled, int mode);
+extern void        func_ov008_02054ba4(int object, int *entry, int visible);
+extern void        func_ov008_020697a4(Ov009PageContext *context);
+extern Ov009Pair  *func_ov008_0205489c(int object, int *entry);
+
+void func_ov008_02067edc(Ov009PageContext *context)
+{
+    Ov009ObjectConfig config = data_ov008_0208f500;
+    Ov009Pair shiftedPosition;
+    Ov009Pair finalPosition;
+    int pageIndex;
+    u32 itemIndex;
+    int object;
+    int *entry;
+    Ov009Pair *position;
+
+    config.resource = func_ov008_02050f84(3);
+    object = func_ov008_02050c54();
+    func_ov008_02054744(object, &config);
+    func_ov008_02054678(object, data_ov008_020904d0, 0x24);
+    func_ov008_0205477c(object, (int)WM_EndKeySharing_0x020698ec);
+    func_020327e0(object, 8);
+    G2x_SetBlendAlpha_((volatile void *)0x04000050, 4, 0x10, 8, 8);
+
+    entry = func_ov008_02054788(object, 0x0b);
+    func_ov008_02054c08(object, entry);
+    entry = func_ov008_02054788(object, 0x0d);
+    func_ov008_02054c08(object, entry);
+
+    context->pageTarget[0].x = 0x100000;
+    context->pageTarget[1].x = 0x138000;
+    context->pageTarget[2].x = 0x170000;
+
+    for (pageIndex = 0; pageIndex < 3; pageIndex++) {
+        for (itemIndex = 0; itemIndex < 8; itemIndex++) {
+            entry = func_ov008_02054788(
+                object, data_ov008_0208f588[pageIndex][itemIndex]);
+            position = func_ov008_02054820(object, entry);
+            context->cellOffset[pageIndex][itemIndex].x = position->x;
+            context->cellOffset[pageIndex][itemIndex].y = position->y;
+            shiftedPosition = *position;
+            shiftedPosition.x += 0x100000;
+            func_ov008_02054858(object, entry, &shiftedPosition);
+            func_ov008_02054c08(object, entry);
+        }
+    }
+
+    entry = func_ov008_02054788(object, 0x14);
+    func_ov008_02054d90(object, entry, 2);
+    entry = func_ov008_02054788(object, 0x15);
+    func_ov008_02054d90(object, entry, 2);
+
+    func_ov008_02068d58(1, 0);
+
+    entry = func_ov008_02054788(object, 0x3c);
+    func_ov008_02054d90(object, entry, 2);
+    func_ov008_02054ba4(object, entry, 0);
+
+    func_ov008_020697a4(context);
+
+    entry = func_ov008_02054788(object, 0x11);
+    func_ov008_02054ba4(object, entry, 0);
+
+    entry = func_ov008_02054788(object, 0x10);
+    position = func_ov008_0205489c(object, entry);
+    finalPosition = *position;
+    finalPosition.x += 0x8000;
+    func_ov008_02054858(object, entry, &finalPosition);
+}

--- a/src/overlays/ov008/calls/func_ov008_0206821c.c
+++ b/src/overlays/ov008/calls/func_ov008_0206821c.c
@@ -1,0 +1,80 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct TileSurfaceCfg {
+    u32 field00;
+    u32 field04;
+    u32 widthTiles;
+    u32 heightTiles;
+    u32 rowTiles;
+    u32 paletteIndex;
+    int vramTarget;
+    u32 field1c;
+    void *pixels;
+    u32 field24;
+} TileSurfaceCfg;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x158];
+    u8 varRecords[0x0c];
+    u8 surface168[0x3c];
+    u8 surface1a4[0x3c];
+    u8 surface1e0[1];
+} Ov009SaveContext;
+
+extern const TileSurfaceCfg data_ov008_0208f538;
+extern const TileSurfaceCfg data_ov008_0208f560;
+extern const TileSurfaceCfg data_ov008_0208f510;
+
+extern void *func_ov008_02050e74(void);
+extern int func_ov008_02050c7c(int slot);
+extern void func_0202ff8c(void *surface, const TileSurfaceCfg *config);
+extern u16 *func_ov008_02055c84(void *records, int index);
+extern void func_ov008_02068120(
+    void *surface,
+    int x,
+    int y,
+    int style,
+    const u16 *text,
+    int shadow
+);
+extern void func_ov008_020681b0(
+    void *surface,
+    int x,
+    int y,
+    int style,
+    const u16 *text
+);
+extern void func_020300f8(void *surface);
+extern void func_ov008_02050b3c(int slot);
+
+void func_ov008_0206821c(Ov009SaveContext *ctx)
+{
+    TileSurfaceCfg config168 = data_ov008_0208f538;
+    TileSurfaceCfg config1e0 = data_ov008_0208f560;
+    TileSurfaceCfg config1a4 = data_ov008_0208f510;
+    const u16 *text;
+
+    config168.pixels = func_ov008_02050e74();
+    config168.vramTarget = func_ov008_02050c7c(9);
+    config1a4.pixels = func_ov008_02050e74();
+    config1a4.vramTarget = func_ov008_02050c7c(9);
+    config1e0.pixels = func_ov008_02050e74();
+    config1e0.vramTarget = func_ov008_02050c7c(9);
+
+    func_0202ff8c(ctx->surface168, &config168);
+    func_0202ff8c(ctx->surface1a4, &config1a4);
+    func_0202ff8c(ctx->surface1e0, &config1e0);
+
+    text = func_ov008_02055c84(ctx->varRecords, 0);
+    func_ov008_02068120(ctx->surface168, 0x8e, 2, 2, text, 1);
+
+    text = func_ov008_02055c84(ctx->varRecords, 1);
+    func_ov008_020681b0(ctx->surface1a4, 0x62, 0, 2, text);
+
+    func_020300f8(ctx->surface1a4);
+    func_020300f8(ctx->surface168);
+    func_020300f8(ctx->surface1e0);
+    func_ov008_02050b3c(9);
+}

--- a/src/overlays/ov008/calls/func_ov008_02069180.c
+++ b/src/overlays/ov008/calls/func_ov008_02069180.c
@@ -1,0 +1,51 @@
+typedef unsigned char u8;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x64];
+    int pending;
+} Ov009SaveContext;
+
+typedef struct Ov009SlotReleaseConfig {
+    int targetValue;
+    int currentValue;
+} Ov009SlotReleaseConfig;
+
+extern const int data_ov008_0208f4e8[2];
+extern int func_ov008_02050c54(void);
+extern int func_ov008_02054788(int manager, int id);
+extern int *func_ov008_02054820(int manager, int entry);
+extern void func_ov008_02054858(
+    int manager,
+    int entry,
+    Ov009SlotReleaseConfig *config
+);
+
+void func_ov008_02069180(Ov009SaveContext *ctx)
+{
+    Ov009SlotReleaseConfig config;
+    unsigned int i;
+    int manager = func_ov008_02050c54();
+
+    for (i = 0; i < 2; i++) {
+        int entry;
+        int id = data_ov008_0208f4e8[i];
+        entry = func_ov008_02054788(manager, id);
+        int *slot = func_ov008_02054820(manager, entry);
+
+        config.currentValue = slot[1];
+        if (ctx->pending != 0) {
+            if (id == 0x15) {
+                config.targetValue = 0x28000;
+            } else {
+                config.targetValue = 0x88000;
+            }
+        } else {
+            if (id == 0x15) {
+                config.targetValue = 0x88000;
+            } else {
+                config.targetValue = 0x28000;
+            }
+        }
+        func_ov008_02054858(manager, entry, &config);
+    }
+}

--- a/src/overlays/ov008/calls/func_ov008_020697a4.c
+++ b/src/overlays/ov008/calls/func_ov008_020697a4.c
@@ -1,0 +1,82 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct Ov009SummaryRow {
+    u8 pad000[0x10];
+    int state;
+    u8 pad014[4];
+    int selectedValue;
+} Ov009SummaryRow;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x10];
+    Ov009SummaryRow rows[3];
+} Ov009SaveContext;
+
+extern int func_ov008_02050c54(void);
+extern int func_ov008_02054788(int manager, int id);
+extern void func_ov008_02054d90(int manager, int entry, int slot);
+extern void func_ov008_02054c80(int manager, int entry, u16 value);
+extern void func_ov008_02054ba4(int manager, int entry, int visible);
+extern const int data_ov008_0208f588[3][8];
+
+void func_ov008_020697a4(Ov009SaveContext *ctx)
+{
+    int rowIndex;
+    u32 itemIndex;
+    int manager;
+    int entry;
+    int itemEntry;
+    Ov009SummaryRow *row;
+
+    manager = func_ov008_02050c54();
+    rowIndex = 0;
+    row = ctx->rows;
+    do {
+        entry = func_ov008_02054788(manager, rowIndex + 1);
+        func_ov008_02054d90(manager, entry, 3);
+        if (row->state == 1) {
+            func_ov008_02054c80(
+                manager,
+                entry,
+                (u16)(*(int *)((u8 *)ctx + 0x28) + 2)
+            );
+        } else if (row->state == 2) {
+            func_ov008_02054c80(manager, entry, 0);
+        } else {
+            func_ov008_02054c80(manager, entry, 1);
+        }
+
+        itemIndex = 0;
+        do {
+            itemEntry = func_ov008_02054788(
+                manager,
+                data_ov008_0208f588[rowIndex][itemIndex]
+            );
+
+            switch (itemIndex) {
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+                if (row->state == 1) {
+                    func_ov008_02054ba4(manager, itemEntry, 1);
+                } else {
+                    func_ov008_02054ba4(manager, itemEntry, 0);
+                }
+                break;
+            default:
+                func_ov008_02054ba4(manager, itemEntry, 1);
+                break;
+            }
+            itemIndex++;
+        } while (itemIndex < 8);
+
+        row++;
+        ctx = (Ov009SaveContext *)((u8 *)ctx + 0x1c);
+        rowIndex++;
+    } while (rowIndex < 3);
+}


### PR DESCRIPTION
Closes #30.

4 functions in ov008 as matching C:

- `func_ov008_02067edc` (580 bytes)
- `func_ov008_0206821c` (336 bytes)
- `func_ov008_02069180` (164 bytes)
- `func_ov008_020697a4` (328 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #30
