### PR TITLE
Decompile 3 functions in ov015

### DIFF
--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -60,6 +60,10 @@ src/overlays/ov015/calls/func_ov015_0208073c.c:
     complete
     .text       start:0x0208073c end:0x0208075c
 
+src/overlays/ov015/calls/func_ov015_0208075c.c:
+    complete
+    .text       start:0x0208075c end:0x02080794
+
 src/overlays/ov015/calls/func_ov015_020807cc.c:
     complete
     .text       start:0x020807cc end:0x020807f2
@@ -71,6 +75,14 @@ src/overlays/ov015/auto/func_ov015_02081284.c:
 src/overlays/ov015/calls/func_ov015_020817bc.c:
     complete
     .text       start:0x020817bc end:0x020817f0
+
+src/overlays/ov015/calls/func_ov015_020817f0.c:
+    complete
+    .text       start:0x020817f0 end:0x02081824
+
+src/overlays/ov015/calls/func_ov015_02081978.c:
+    complete
+    .text       start:0x02081978 end:0x020819a0
 
 src/overlays/ov015/calls/func_ov015_020819a0.c:
     complete

--- a/src/overlays/ov015/calls/func_ov015_0208075c.c
+++ b/src/overlays/ov015/calls/func_ov015_0208075c.c
@@ -1,0 +1,23 @@
+typedef unsigned char u8;
+
+int func_01fffe14(void);
+int func_01fffde0(int idx);
+int func_ov022_020ad61c(int arg0, int arg1);
+
+typedef struct {
+    u8 pad_00[0x1c];
+    u8 field_1c[1];
+    u8 pad_1d[0x40 - 0x1d];
+    u8 flags_40;
+} Obj_ov015_0208075c;
+
+void *func_ov015_0208075c(Obj_ov015_0208075c *obj)
+{
+    if (obj->flags_40 & 2)
+    {
+        if (func_ov022_020ad61c(func_01fffde0(func_01fffe14()), 0xc))
+            return obj->field_1c;
+    }
+
+    return 0;
+}

--- a/src/overlays/ov015/calls/func_ov015_020817f0.c
+++ b/src/overlays/ov015/calls/func_ov015_020817f0.c
@@ -1,0 +1,10 @@
+extern void func_ov002_0207c618(short *pAnim, int nBlend, int nFrame);
+extern void func_0202af1c(unsigned short *p);
+
+void func_ov015_020817f0(int this_, short *arg1, int arg2, int arg3) {
+    unsigned short flags = *(unsigned short *)(this_ + 0x12);
+    if ((flags & 4) && (flags & 4)) {
+        func_ov002_0207c618(arg1, arg2, arg3);
+        func_0202af1c((unsigned short *)arg1);
+    }
+}

--- a/src/overlays/ov015/calls/func_ov015_02081978.c
+++ b/src/overlays/ov015/calls/func_ov015_02081978.c
@@ -1,0 +1,9 @@
+#pragma thumb on
+extern void func_0202a7dc(int this_);
+extern void func_0202ba18(unsigned char *sub);
+
+void func_ov015_02081978(char *obj) {
+    func_0202a7dc((int)(obj + 0x61c));
+    func_0202ba18((unsigned char *)(obj + 0x498));
+    *(unsigned short *)(obj + 0x12) &= ~4;
+}


### PR DESCRIPTION
Closes #32.

3 functions in ov015 as matching C:

- `func_ov015_0208075c` (56 bytes)
- `func_ov015_020817f0` (52 bytes)
- `func_ov015_02081978` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #32
