### PR TITLE
Decompile 3 functions in ov016

### DIFF
--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -63,6 +63,10 @@ src/overlays/ov016/auto/func_ov016_02080198.c:
     complete
     .text       start:0x02080198 end:0x020801a0
 
+src/overlays/ov016/calls/func_ov016_02080440.c:
+    complete
+    .text       start:0x02080440 end:0x02080480
+
 src/overlays/ov016/calls/func_ov016_0208076c.c:
     complete
     .text       start:0x0208076c end:0x02080780
@@ -119,6 +123,10 @@ src/overlays/ov016/calls/func_ov016_020814b0.c:
     complete
     .text       start:0x020814b0 end:0x0208154e
 
+src/overlays/ov016/calls/func_ov016_020815e8.c:
+    complete
+    .text       start:0x020815e8 end:0x02081624
+
 src/overlays/ov016/calls/func_ov016_020819a8.c:
     complete
     .text       start:0x020819a8 end:0x020819c4
@@ -146,6 +154,10 @@ src/overlays/ov016/auto/func_ov016_02081d20.c:
 src/overlays/ov016/calls/func_ov016_02081f64.c:
     complete
     .text       start:0x02081f64 end:0x02082020
+
+src/overlays/ov016/calls/func_ov016_02082294.c:
+    complete
+    .text       start:0x02082294 end:0x020822c0
 
 src/overlays/ov016/calls/func_ov016_020822c0.c:
     complete

--- a/src/overlays/ov016/calls/func_ov016_02080440.c
+++ b/src/overlays/ov016/calls/func_ov016_02080440.c
@@ -1,0 +1,26 @@
+typedef unsigned short u16;
+
+typedef struct {
+    char _0[0xe0];
+    short slots[1];   /* +0xe0 */
+} Ov002SlotTable;
+
+typedef struct {
+    char _0[0x12];
+    u16 flags;          /* +0x12 */
+    char _14[0x1c0 - 0x14];
+    int accum;           /* +0x1c0 */
+} Obj;
+
+extern int func_ov002_0207687c(void);
+extern void func_ov002_0207c67c(Ov002SlotTable *tbl, int param_2);
+
+void func_ov016_02080440(Obj *self) {
+    if ((self->flags & 4) != 0) {
+        self->accum += func_ov002_0207687c();
+        if (self->accum >= 0x1d000) {
+            self->accum = 0x1d000;
+        }
+        func_ov002_0207c67c((Ov002SlotTable *)((char *)self + 0x2c), self->accum);
+    }
+}

--- a/src/overlays/ov016/calls/func_ov016_020815e8.c
+++ b/src/overlays/ov016/calls/func_ov016_020815e8.c
@@ -1,0 +1,24 @@
+typedef unsigned short u16;
+
+extern void func_ov002_0207c618(short *pAnim, int nBlend, int nFrame);
+extern void func_0202af1c(u16 *p);
+
+void func_ov016_020815e8(char *self, int type, int field624, int field620) {
+    u16 flags;
+    short *pAnim;
+
+    *(char *)(self + 0x61e) = (char)type;
+    *(int *)(self + 0x624) = field624;
+    *(int *)(self + 0x620) = field620;
+
+    flags = *(u16 *)(self + 0x12);
+    pAnim = (short *)(self + 0x4a8);
+    if ((flags & 4) != 0) {
+        if ((flags & 4) != 0) {
+            func_ov002_0207c618(pAnim,
+                                 *(signed char *)(self + 0x61e),
+                                 *(int *)(self + 0x620));
+            func_0202af1c((u16 *)pAnim);
+        }
+    }
+}

--- a/src/overlays/ov016/calls/func_ov016_02082294.c
+++ b/src/overlays/ov016/calls/func_ov016_02082294.c
@@ -1,0 +1,8 @@
+extern void func_ov016_020821f8(void *self, int value, int flag);
+
+void func_ov016_02082294(char *self, char *arg1) {
+    if ((unsigned char)arg1[0] == 1) {
+        func_ov016_020821f8(self, *(int *)(arg1 + 4), 1);
+    }
+    self[0x2bc] = 0;
+}


### PR DESCRIPTION
Closes #34.

3 functions in ov016 as matching C:

- `func_ov016_02080440` (64 bytes)
- `func_ov016_020815e8` (60 bytes)
- `func_ov016_02082294` (44 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #34
