### PR TITLE
Drop the dead fourth parameter from Ov022_RequestVoiceIds

### DIFF
--- a/src/overlays/ov022/calls/func_ov022_020a4798.c
+++ b/src/overlays/ov022/calls/func_ov022_020a4798.c
@@ -47,7 +47,7 @@ extern unsigned int func_020358f4(int nSlot, int nParam);
 #define MODE_TABLE_DRIVEN 4
 #define VOICE_PARAM 0x58
 
-void func_ov022_020a4798(struct Actor *pActor, short nId, u16 nArg2, int nArg3)
+void func_ov022_020a4798(struct Actor *pActor, short nId, u16 nArg2)
 {
     struct KindIdTable tbl;
 


### PR DESCRIPTION
Closes #38.

func_ov022_020a4798 was declared with four parameters, but nArg3 appears
exactly once in the file -- in the parameter list -- and is never read.
Two independent call sites (func_ov043_020b3234, func_ov062_020b5a34)
pass three arguments and set only r0/r1/r2, never writing r3, which is
what the ROM does. Calling it with a fourth argument does not match:
byte diff @0x28.

So the definition was the thing that disagreed with the ROM, not the
callers. Removing the parameter leaves the function byte-identical, 304
bytes and 7 relocations either way, because an unused parameter
generates no code.

tools/audit_extern_sig.py reports 475 files whose extern still
contradicts the definition it calls. This was one of them; the rest are
unexamined.

## Verification

`tools/verify_idx.py` reports `>>> MATCH <<<` for func_ov022_020a4798 before and after. My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
