### PR TITLE
Decompile 1 function in ov023

### DIFF
--- a/config/arm9/overlays/ov023/delinks.txt
+++ b/config/arm9/overlays/ov023/delinks.txt
@@ -408,6 +408,10 @@ src/overlays/ov023/calls/func_ov023_02087114.c:
     complete
     .text       start:0x02087114 end:0x02087160
 
+src/overlays/ov023/auto/func_ov023_02087210.c:
+    complete
+    .text       start:0x02087210 end:0x02087234
+
 src/overlays/ov023/calls/func_ov023_02087510.c:
     complete
     .text       start:0x02087510 end:0x02087564

--- a/src/overlays/ov023/auto/func_ov023_02087210.c
+++ b/src/overlays/ov023/auto/func_ov023_02087210.c
@@ -1,0 +1,22 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+struct Ov023Work
+{
+    /* 0x0000 */ u8 pad_0[0x159c];
+    /* 0x159c */ u32 field_159c;
+    /* 0x15a0 */ u32 field_15a0;
+    /* 0x15a4 */ u32 field_15a4;
+    /* 0x15a8 */ u32 field_15a8;
+    /* 0x15ac */ u8 pad_15ac[8];
+    /* 0x15b4 */ u32 field_15b4;
+};
+
+void func_ov023_02087210(struct Ov023Work *work)
+{
+    work->field_159c = work->field_15a0 = work->field_15a4 = 0;
+    if (work->field_15b4 != 2)
+    {
+        work->field_15a8 = 0;
+    }
+}


### PR DESCRIPTION
Closes #40.

One function in ov023 as matching C:

- `func_ov023_02087210` (36 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #40
