### PR TITLE
Decompile 7 functions in ov025

### DIFF
--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -1164,6 +1164,10 @@ src/overlays/ov025/calls/func_ov025_0208b0a4.c:
     complete
     .text       start:0x0208b0a4 end:0x0208b274
 
+src/overlays/ov025/calls/func_ov025_0208b6d8.c:
+    complete
+    .text       start:0x0208b6d8 end:0x0208b7d0
+
 src/overlays/ov025/calls/func_ov025_0208bda0.c:
     complete
     .text       start:0x0208bda0 end:0x0208bdf8
@@ -1880,6 +1884,10 @@ src/overlays/ov025/calls/func_ov025_0209a190.c:
     complete
     .text       start:0x0209a190 end:0x0209a2bc
 
+src/overlays/ov025/calls/func_ov025_0209a2bc.c:
+    complete
+    .text       start:0x0209a2bc end:0x0209a500
+
 src/overlays/ov025/calls/func_ov025_0209a500.c:
     complete
     .text       start:0x0209a500 end:0x0209a590
@@ -1887,6 +1895,10 @@ src/overlays/ov025/calls/func_ov025_0209a500.c:
 src/overlays/ov025/calls/func_ov025_0209a590.c:
     complete
     .text       start:0x0209a590 end:0x0209a5fc
+
+src/overlays/ov025/calls/func_ov025_0209a5fc.c:
+    complete
+    .text       start:0x0209a5fc end:0x0209a74c
 
 src/overlays/ov025/calls/func_ov025_0209a74c.c:
     complete
@@ -1924,9 +1936,17 @@ src/overlays/ov025/calls/func_ov025_0209b248.c:
     complete
     .text       start:0x0209b248 end:0x0209b560
 
+src/overlays/ov025/calls/func_ov025_0209b560.c:
+    complete
+    .text       start:0x0209b560 end:0x0209b604
+
 src/overlays/ov025/calls/func_ov025_0209b700.c:
     complete
     .text       start:0x0209b700 end:0x0209b7a4
+
+src/overlays/ov025/calls/func_ov025_0209bb84.c:
+    complete
+    .text       start:0x0209bb84 end:0x0209bccc
 
 src/calls/WM_EndKeySharing_0x0209bccc.c:
     complete
@@ -2123,6 +2143,10 @@ src/overlays/ov025/calls/func_ov025_020a018c.c:
 src/overlays/ov025/calls/func_ov025_020a01bc.c:
     complete
     .text       start:0x020a01bc end:0x020a01f8
+
+src/overlays/ov025/calls/func_ov025_020a01f8.c:
+    complete
+    .text       start:0x020a01f8 end:0x020a026c
 
 src/overlays/ov025/calls/func_ov025_020a086c.c:
     complete
@@ -2651,6 +2675,10 @@ src/overlays/ov025/calls/func_ov025_020ada10.c:
 src/overlays/ov025/calls/func_ov025_020ada44.c:
     complete
     .text       start:0x020ada44 end:0x020ada88
+
+src/overlays/ov025/calls/func_ov025_020adc7c.c:
+    complete
+    .text       start:0x020adc7c end:0x020adcbc
 
 src/overlays/ov025/calls/func_ov025_020adcbc.c:
     complete

--- a/src/overlays/ov025/calls/func_ov025_0208b6d8.c
+++ b/src/overlays/ov025/calls/func_ov025_0208b6d8.c
@@ -1,0 +1,54 @@
+/* func_ov025_0208b6d8 -- Ov008_SetupMenuBgCells (248 B, 18 relocs).
+ * Loads the main-menu background graphics and seeds its cell list. Sets the 3D H-offset,
+ * grabs the menu cell-list context (02050c28), unpacks archive subfile 0xa into a resource
+ * cell (func_02024c94 takes FIVE args -- the trailing stack 0 is the ROM's str r2,[sp]),
+ * uploads the BG3 palette and character data from the unpacked blocks, frees the temp
+ * resource, attaches subfile 7 (02055534), then registers four cells (tags 0,1,2,3 -- 3 is
+ * deliberately skipped) by looking each up (02055808) and adding it (0205589c).
+ * Resource-cell layout mirrors the ov000 loader (screen/character/palette pointer trio). */
+typedef unsigned char  u8;
+typedef unsigned short u16;
+typedef unsigned int   u32;
+
+typedef struct Ov008CharacterBlock { u8 pad_0000[0x10]; u32 size; void *data; } Ov008CharacterBlock;
+typedef struct Ov008PaletteBlock   { u8 pad_0000[0x08]; u32 size; void *data; } Ov008PaletteBlock;
+typedef struct Ov008ScreenBlock    { u8 pad_0000[0x08]; u32 size; u8 data[1]; } Ov008ScreenBlock;
+typedef struct Ov008ResourceCell {
+    Ov008ScreenBlock    *screen;
+    Ov008CharacterBlock *character;
+    Ov008PaletteBlock   *palette;
+} Ov008ResourceCell;
+
+extern void  G3X_SetHOffset(int off);
+extern void *func_ov025_02084a50(void);
+extern u32   func_ov025_02084d18(int subfile);
+extern void *func_0201ef9c(u32 handle, int heapId);
+extern void  func_02024c94(Ov008ResourceCell *cell, void *resource, int a, int b, int c);
+extern void  GX_LoadBGPltt(const void *source, u32 offset, u32 size);
+extern void  GX_LoadBG3Char(const void *source, u32 offset, u32 size);
+extern void  NNSi_FndFreeFromDefaultHeap(void *allocation);
+extern void  func_ov025_020891dc(void *ctx, u32 handle);
+extern void *func_ov025_020894b0(void *ctx, int tag);
+extern void  func_ov025_02089544(void *ctx, void *cell);
+
+void func_ov025_0208b6d8(void)
+{
+    void *ctx;
+    void *resource;
+    Ov008ResourceCell cell;
+
+    G3X_SetHOffset(-0x3b);
+    ctx = func_ov025_02084a50();
+    resource = func_0201ef9c(func_ov025_02084d18(0xa), 0xe);
+    func_02024c94(&cell, resource, 0, 0, 0);
+    GX_LoadBGPltt(cell.palette->data, 0, cell.palette->size);
+    GX_LoadBG3Char(cell.character->data, 0, cell.character->size);
+    if (resource != 0) {
+        NNSi_FndFreeFromDefaultHeap(resource);
+    }
+    func_ov025_020891dc(ctx, func_ov025_02084d18(7));
+    func_ov025_02089544(ctx, func_ov025_020894b0(ctx, 0));
+    func_ov025_02089544(ctx, func_ov025_020894b0(ctx, 1));
+    func_ov025_02089544(ctx, func_ov025_020894b0(ctx, 2));
+    func_ov025_02089544(ctx, func_ov025_020894b0(ctx, 3));
+}

--- a/src/overlays/ov025/calls/func_ov025_0209a2bc.c
+++ b/src/overlays/ov025/calls/func_ov025_0209a2bc.c
@@ -1,0 +1,115 @@
+typedef unsigned char u8;
+typedef unsigned int  u32;
+
+typedef struct Ov009Pair {
+    int x;
+    int y;
+} Ov009Pair;
+
+typedef struct Ov009PageContext {
+    int pageIndex;
+    int fallbackPage;
+    int activeState;
+    u8 pad_00c[0x68 - 0x0c];
+    Ov009Pair cellOffset[3][8];
+    Ov009Pair pageTarget[3];
+    Ov009Pair pageCurrent[3];
+} Ov009PageContext;
+
+typedef struct Ov009ObjectConfig {
+    int resource;
+    int field_04;
+    int field_08;
+    int field_0c;
+} Ov009ObjectConfig;
+
+extern const Ov009ObjectConfig data_ov025_020b4060;
+extern const char data_ov025_020b4e9c[];
+extern const int data_ov025_020b40e8[3][8];
+extern void WM_EndKeySharing_0x0209bccc(void);
+
+extern int         func_ov025_02084d94(int index);
+extern int         func_ov025_02084a7c(void);
+extern void        func_ov025_020883f8(int object,
+                                      const Ov009ObjectConfig *config);
+extern void        func_ov025_0208832c(int object, const void *resource,
+                                      int value);
+extern void        func_ov025_02088430(int object, int value);
+extern void        func_020327e0(int object, int value);
+extern void        G2x_SetBlendAlpha_(volatile void *reg, int firstTarget,
+                                     int secondTarget, int eva, int evb);
+extern int        *func_ov025_0208843c(int object, int id);
+extern void        func_ov025_020888b0(int object, int *entry);
+extern Ov009Pair  *func_ov025_020884c8(int object, int *entry);
+extern void        func_ov025_02088500(int object, int *entry,
+                                      const Ov009Pair *position);
+extern void        func_ov025_02088a38(int object, int *entry, int value);
+extern void        func_ov025_0209b138(int enabled, int mode);
+extern void        func_ov025_0208884c(int object, int *entry, int visible);
+extern void        func_ov025_0209bb84(Ov009PageContext *context);
+extern Ov009Pair  *func_ov025_02088544(int object, int *entry);
+
+void func_ov025_0209a2bc(Ov009PageContext *context)
+{
+    Ov009ObjectConfig config = data_ov025_020b4060;
+    Ov009Pair shiftedPosition;
+    Ov009Pair finalPosition;
+    int pageIndex;
+    u32 itemIndex;
+    int object;
+    int *entry;
+    Ov009Pair *position;
+
+    config.resource = func_ov025_02084d94(3);
+    object = func_ov025_02084a7c();
+    func_ov025_020883f8(object, &config);
+    func_ov025_0208832c(object, data_ov025_020b4e9c, 0x24);
+    func_ov025_02088430(object, (int)WM_EndKeySharing_0x0209bccc);
+    func_020327e0(object, 8);
+    G2x_SetBlendAlpha_((volatile void *)0x04000050, 4, 0x10, 8, 8);
+
+    entry = func_ov025_0208843c(object, 0x0b);
+    func_ov025_020888b0(object, entry);
+    entry = func_ov025_0208843c(object, 0x0d);
+    func_ov025_020888b0(object, entry);
+
+    context->pageTarget[0].x = 0x100000;
+    context->pageTarget[1].x = 0x138000;
+    context->pageTarget[2].x = 0x170000;
+
+    for (pageIndex = 0; pageIndex < 3; pageIndex++) {
+        for (itemIndex = 0; itemIndex < 8; itemIndex++) {
+            entry = func_ov025_0208843c(
+                object, data_ov025_020b40e8[pageIndex][itemIndex]);
+            position = func_ov025_020884c8(object, entry);
+            context->cellOffset[pageIndex][itemIndex].x = position->x;
+            context->cellOffset[pageIndex][itemIndex].y = position->y;
+            shiftedPosition = *position;
+            shiftedPosition.x += 0x100000;
+            func_ov025_02088500(object, entry, &shiftedPosition);
+            func_ov025_020888b0(object, entry);
+        }
+    }
+
+    entry = func_ov025_0208843c(object, 0x14);
+    func_ov025_02088a38(object, entry, 2);
+    entry = func_ov025_0208843c(object, 0x15);
+    func_ov025_02088a38(object, entry, 2);
+
+    func_ov025_0209b138(1, 0);
+
+    entry = func_ov025_0208843c(object, 0x3c);
+    func_ov025_02088a38(object, entry, 2);
+    func_ov025_0208884c(object, entry, 0);
+
+    func_ov025_0209bb84(context);
+
+    entry = func_ov025_0208843c(object, 0x11);
+    func_ov025_0208884c(object, entry, 0);
+
+    entry = func_ov025_0208843c(object, 0x10);
+    position = func_ov025_02088544(object, entry);
+    finalPosition = *position;
+    finalPosition.x += 0x8000;
+    func_ov025_02088500(object, entry, &finalPosition);
+}

--- a/src/overlays/ov025/calls/func_ov025_0209a5fc.c
+++ b/src/overlays/ov025/calls/func_ov025_0209a5fc.c
@@ -1,0 +1,80 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct TileSurfaceCfg {
+    u32 field00;
+    u32 field04;
+    u32 widthTiles;
+    u32 heightTiles;
+    u32 rowTiles;
+    u32 paletteIndex;
+    int vramTarget;
+    u32 field1c;
+    void *pixels;
+    u32 field24;
+} TileSurfaceCfg;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x158];
+    u8 varRecords[0x0c];
+    u8 surface168[0x3c];
+    u8 surface1a4[0x3c];
+    u8 surface1e0[1];
+} Ov009SaveContext;
+
+extern const TileSurfaceCfg data_ov025_020b4098;
+extern const TileSurfaceCfg data_ov025_020b40c0;
+extern const TileSurfaceCfg data_ov025_020b4070;
+
+extern void *func_ov025_02084c84(void);
+extern int func_ov025_02084aa4(int slot);
+extern void func_0202ff8c(void *surface, const TileSurfaceCfg *config);
+extern u16 *func_ov025_02089894(void *records, int index);
+extern void func_ov025_0209a500(
+    void *surface,
+    int x,
+    int y,
+    int style,
+    const u16 *text,
+    int shadow
+);
+extern void func_ov025_0209a590(
+    void *surface,
+    int x,
+    int y,
+    int style,
+    const u16 *text
+);
+extern void func_020300f8(void *surface);
+extern void func_ov025_02084964(int slot);
+
+void func_ov025_0209a5fc(Ov009SaveContext *ctx)
+{
+    TileSurfaceCfg config168 = data_ov025_020b4098;
+    TileSurfaceCfg config1e0 = data_ov025_020b40c0;
+    TileSurfaceCfg config1a4 = data_ov025_020b4070;
+    const u16 *text;
+
+    config168.pixels = func_ov025_02084c84();
+    config168.vramTarget = func_ov025_02084aa4(9);
+    config1a4.pixels = func_ov025_02084c84();
+    config1a4.vramTarget = func_ov025_02084aa4(9);
+    config1e0.pixels = func_ov025_02084c84();
+    config1e0.vramTarget = func_ov025_02084aa4(9);
+
+    func_0202ff8c(ctx->surface168, &config168);
+    func_0202ff8c(ctx->surface1a4, &config1a4);
+    func_0202ff8c(ctx->surface1e0, &config1e0);
+
+    text = func_ov025_02089894(ctx->varRecords, 0);
+    func_ov025_0209a500(ctx->surface168, 0x8e, 2, 2, text, 1);
+
+    text = func_ov025_02089894(ctx->varRecords, 1);
+    func_ov025_0209a590(ctx->surface1a4, 0x62, 0, 2, text);
+
+    func_020300f8(ctx->surface1a4);
+    func_020300f8(ctx->surface168);
+    func_020300f8(ctx->surface1e0);
+    func_ov025_02084964(9);
+}

--- a/src/overlays/ov025/calls/func_ov025_0209b560.c
+++ b/src/overlays/ov025/calls/func_ov025_0209b560.c
@@ -1,0 +1,51 @@
+typedef unsigned char u8;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x64];
+    int pending;
+} Ov009SaveContext;
+
+typedef struct Ov009SlotReleaseConfig {
+    int targetValue;
+    int currentValue;
+} Ov009SlotReleaseConfig;
+
+extern const int data_ov025_020b4048[2];
+extern int func_ov025_02084a7c(void);
+extern int func_ov025_0208843c(int manager, int id);
+extern int *func_ov025_020884c8(int manager, int entry);
+extern void func_ov025_02088500(
+    int manager,
+    int entry,
+    Ov009SlotReleaseConfig *config
+);
+
+void func_ov025_0209b560(Ov009SaveContext *ctx)
+{
+    Ov009SlotReleaseConfig config;
+    unsigned int i;
+    int manager = func_ov025_02084a7c();
+
+    for (i = 0; i < 2; i++) {
+        int entry;
+        int id = data_ov025_020b4048[i];
+        entry = func_ov025_0208843c(manager, id);
+        int *slot = func_ov025_020884c8(manager, entry);
+
+        config.currentValue = slot[1];
+        if (ctx->pending != 0) {
+            if (id == 0x15) {
+                config.targetValue = 0x28000;
+            } else {
+                config.targetValue = 0x88000;
+            }
+        } else {
+            if (id == 0x15) {
+                config.targetValue = 0x88000;
+            } else {
+                config.targetValue = 0x28000;
+            }
+        }
+        func_ov025_02088500(manager, entry, &config);
+    }
+}

--- a/src/overlays/ov025/calls/func_ov025_0209bb84.c
+++ b/src/overlays/ov025/calls/func_ov025_0209bb84.c
@@ -1,0 +1,82 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct Ov009SummaryRow {
+    u8 pad000[0x10];
+    int state;
+    u8 pad014[4];
+    int selectedValue;
+} Ov009SummaryRow;
+
+typedef struct Ov009SaveContext {
+    u8 pad000[0x10];
+    Ov009SummaryRow rows[3];
+} Ov009SaveContext;
+
+extern int func_ov025_02084a7c(void);
+extern int func_ov025_0208843c(int manager, int id);
+extern void func_ov025_02088a38(int manager, int entry, int slot);
+extern void func_ov025_02088928(int manager, int entry, u16 value);
+extern void func_ov025_0208884c(int manager, int entry, int visible);
+extern const int data_ov025_020b40e8[3][8];
+
+void func_ov025_0209bb84(Ov009SaveContext *ctx)
+{
+    int rowIndex;
+    u32 itemIndex;
+    int manager;
+    int entry;
+    int itemEntry;
+    Ov009SummaryRow *row;
+
+    manager = func_ov025_02084a7c();
+    rowIndex = 0;
+    row = ctx->rows;
+    do {
+        entry = func_ov025_0208843c(manager, rowIndex + 1);
+        func_ov025_02088a38(manager, entry, 3);
+        if (row->state == 1) {
+            func_ov025_02088928(
+                manager,
+                entry,
+                (u16)(*(int *)((u8 *)ctx + 0x28) + 2)
+            );
+        } else if (row->state == 2) {
+            func_ov025_02088928(manager, entry, 0);
+        } else {
+            func_ov025_02088928(manager, entry, 1);
+        }
+
+        itemIndex = 0;
+        do {
+            itemEntry = func_ov025_0208843c(
+                manager,
+                data_ov025_020b40e8[rowIndex][itemIndex]
+            );
+
+            switch (itemIndex) {
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+                if (row->state == 1) {
+                    func_ov025_0208884c(manager, itemEntry, 1);
+                } else {
+                    func_ov025_0208884c(manager, itemEntry, 0);
+                }
+                break;
+            default:
+                func_ov025_0208884c(manager, itemEntry, 1);
+                break;
+            }
+            itemIndex++;
+        } while (itemIndex < 8);
+
+        row++;
+        ctx = (Ov009SaveContext *)((u8 *)ctx + 0x1c);
+        rowIndex++;
+    } while (rowIndex < 3);
+}

--- a/src/overlays/ov025/calls/func_ov025_020a01f8.c
+++ b/src/overlays/ov025/calls/func_ov025_020a01f8.c
@@ -1,0 +1,12 @@
+/* Draw a page-A element via func_020301c8, optionally preceded by a drop-shadow pass offset by
+ * (+1,+1,-1). The element base is page A + 0x78; param_1 is forwarded as the draw's last argument. */
+extern int func_ov025_02084afc(void);
+extern void func_020301c8(int base, int x, int y, int z, unsigned int flags, int arg);
+
+void func_ov025_020a01f8(int param_1, int param_2, int param_3, int param_4, unsigned int param_5, int param_6) {
+    int page = func_ov025_02084afc();
+    if (param_6 != 0) {
+        func_020301c8(page + 0x78, param_2 + 1, param_3 + 1, param_4 - 1, param_5, param_1);
+    }
+    func_020301c8(page + 0x78, param_2, param_3, param_4, param_5, param_1);
+}

--- a/src/overlays/ov025/calls/func_ov025_020adc7c.c
+++ b/src/overlays/ov025/calls/func_ov025_020adc7c.c
@@ -1,0 +1,13 @@
+extern void func_ov025_020ada88(int arg0, int arg1, int arg2);
+
+void func_ov025_020adc7c(int arg0) {
+    int total = *(int *)(arg0 + 0x2d0);
+    int chunk = total / 16;
+    int i;
+
+    for (i = 0; i < 11; i++) {
+        func_ov025_020ada88(arg0, i, i + chunk);
+    }
+
+    *(int *)(arg0 + 0x14) = 1;
+}


### PR DESCRIPTION
Closes #42.

7 functions in ov025 as matching C:

- `func_ov025_0208b6d8` (248 bytes)
- `func_ov025_0209a2bc` (580 bytes)
- `func_ov025_0209a5fc` (336 bytes)
- `func_ov025_0209b560` (164 bytes)
- `func_ov025_0209bb84` (328 bytes)
- `func_ov025_020a01f8` (116 bytes)
- `func_ov025_020adc7c` (64 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #42
