### PR TITLE
Decompile 2 functions in ov026

### DIFF
--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -20,6 +20,14 @@ src/overlays/ov026/auto/func_ov026_02082a3c.c:
     complete
     .text       start:0x02082a3c end:0x02082a44
 
+src/overlays/ov026/calls/func_ov026_02082a44.c:
+    complete
+    .text       start:0x02082a44 end:0x02082a84
+
+src/overlays/ov026/calls/func_ov026_02082a84.c:
+    complete
+    .text       start:0x02082a84 end:0x02082aac
+
 src/overlays/ov026/calls/func_ov026_02082aac.c:
     complete
     .text       start:0x02082aac end:0x02082ad0

--- a/src/overlays/ov026/calls/func_ov026_02082a44.c
+++ b/src/overlays/ov026/calls/func_ov026_02082a44.c
@@ -1,0 +1,16 @@
+/* func_ov026_02082a44 -- restore the capture/blend engines (func_0201e374/3cc with -0x10),
+ * clear the BG-mode/screen-base bits of both DISPCNT registers, and switch the main engine
+ * to the top physical LCD via func_ov002_02076028. */
+typedef volatile unsigned int vu32;
+
+extern void func_0201e374(int a);
+extern void func_0201e3cc(int a);
+extern void func_ov002_02076028(int top);
+
+void func_ov026_02082a44(void) {
+    func_0201e374(-0x10);
+    func_0201e3cc(-0x10);
+    *(vu32 *)0x04000000 &= ~0x1f00;
+    *(vu32 *)0x04001000 &= ~0x1f00;
+    func_ov002_02076028(1);
+}

--- a/src/overlays/ov026/calls/func_ov026_02082a84.c
+++ b/src/overlays/ov026/calls/func_ov026_02082a84.c
@@ -1,0 +1,7 @@
+extern int func_02023930(void *desc, int arg);
+extern int data_ov026_02091200;
+extern int *data_ov026_02091360;
+
+void func_ov026_02082a84(int arg0) {
+    data_ov026_02091360[2] = func_02023930(&data_ov026_02091200, arg0);
+}


### PR DESCRIPTION
Closes #44.

2 functions in ov026 as matching C:

- `func_ov026_02082a44` (64 bytes)
- `func_ov026_02082a84` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #44
