### PR TITLE
Decompile 1 function in ov027

### DIFF
--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -60,6 +60,10 @@ src/overlays/ov027/calls/func_ov027_02083c1c.c:
     complete
     .text       start:0x02083c1c end:0x02083c40
 
+src/overlays/ov027/calls/func_ov027_02083c40.c:
+    complete
+    .text       start:0x02083c40 end:0x02083c76
+
 src/overlays/ov027/calls/func_ov027_02083cb8.c:
     complete
     .text       start:0x02083cb8 end:0x02083ccc

--- a/src/overlays/ov027/calls/func_ov027_02083c40.c
+++ b/src/overlays/ov027/calls/func_ov027_02083c40.c
@@ -1,0 +1,14 @@
+#pragma thumb on
+extern void func_02013484(void *pScreenDst, void *pScreenData, int srcX, int srcY,
+                          int dstX, int dstY, unsigned int dstW, unsigned int dstH,
+                          int width, int height);
+
+void func_ov027_02083c40(int table, int idx) {
+    unsigned short *screenHeader = *(unsigned short **)(table + 0x54);
+    int slot = table + idx * 0x18;
+    func_02013484((void *)(screenHeader + 6), *(void **)(table + 4),
+                  *(int *)(slot + 8), *(int *)(slot + 0xc),
+                  *(int *)(slot + 0x10), *(int *)(slot + 0x14),
+                  screenHeader[0], screenHeader[1],
+                  *(int *)(slot + 0x18), *(int *)(slot + 0x1c));
+}


### PR DESCRIPTION
Closes #46.

One function in ov027 as matching C:

- `func_ov027_02083c40` (54 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #46
