### PR TITLE
Decompile 3 functions in ov043

### DIFF
--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -8,6 +8,14 @@ libs/nitro/snd/calls/SNDi_UnlockMutex_ov043_0x020b3220.c:
     complete
     .text       start:0x020b3220 end:0x020b3234
 
+src/overlays/ov043/calls/func_ov043_020b3234.c:
+    complete
+    .text       start:0x020b3234 end:0x020b3264
+
+src/overlays/ov043/calls/func_ov043_020b3264.c:
+    complete
+    .text       start:0x020b3264 end:0x020b3290
+
 src/overlays/ov043/calls/func_ov043_020b351c.c:
     complete
     .text       start:0x020b351c end:0x020b3544
@@ -35,6 +43,10 @@ src/overlays/ov043/calls/func_ov043_020b4b20.c:
 src/overlays/ov043/calls/func_ov043_020b4b44.c:
     complete
     .text       start:0x020b4b44 end:0x020b4b60
+
+src/overlays/ov043/calls/func_ov043_020b50f8.c:
+    complete
+    .text       start:0x020b50f8 end:0x020b5120
 
 src/overlays/ov043/calls/func_ov043_020b5274.c:
     complete

--- a/src/overlays/ov043/calls/func_ov043_020b3234.c
+++ b/src/overlays/ov043/calls/func_ov043_020b3234.c
@@ -1,0 +1,23 @@
+typedef unsigned short u16;
+
+typedef void *(*VoiceEntryFn)(void);
+
+extern void *NNSi_FndGetCurrentRootHeap(void);
+extern void func_ov043_020b3290(void *pObj);
+extern void func_ov043_020b37dc(void *root);
+extern void func_ov043_020b4734(void *root);
+extern void func_ov022_020a4798(void *pActor, short nId, u16 nArg2);
+extern void *func_ov022_0209fb24(void);
+
+/* Initialize the voice decoder for pObj, then hand back the entry point
+ * (func_ov022_0209fb24) without calling it -- the caller invokes it later. */
+VoiceEntryFn func_ov043_020b3234(void *pObj) {
+    void *root = NNSi_FndGetCurrentRootHeap();
+
+    func_ov043_020b3290(pObj);
+    func_ov043_020b37dc(root);
+    func_ov043_020b4734(root);
+    func_ov022_020a4798(root, 0x4f, 0xc4);
+
+    return (VoiceEntryFn)func_ov022_0209fb24;
+}

--- a/src/overlays/ov043/calls/func_ov043_020b3264.c
+++ b/src/overlays/ov043/calls/func_ov043_020b3264.c
@@ -1,0 +1,15 @@
+extern void *NNSi_FndGetCurrentRootHeap(void);
+extern int func_ov043_020b3810(int param_1);
+extern void func_ov043_020b47fc(int param_1);
+extern void func_ov043_020b3ad0(char *obj);
+extern void func_ov022_0209fab4(char *root);
+extern int data_ov043_020b58e0;
+
+void func_ov043_020b3264(void) {
+    int root = (int)NNSi_FndGetCurrentRootHeap();
+    func_ov043_020b3810(root);
+    func_ov043_020b47fc(root);
+    func_ov043_020b3ad0((char *)root);
+    func_ov022_0209fab4((char *)root);
+    data_ov043_020b58e0 = 0;
+}

--- a/src/overlays/ov043/calls/func_ov043_020b50f8.c
+++ b/src/overlays/ov043/calls/func_ov043_020b50f8.c
@@ -1,0 +1,7 @@
+extern void func_0202aa9c(void *p);
+
+void func_ov043_020b50f8(char *p) {
+    if (*(int *)p != 1) return;
+    func_0202aa9c(p + 4);
+    func_0202aa9c(p + 0x10c);
+}


### PR DESCRIPTION
Closes #52.

3 functions in ov043 as matching C:

- `func_ov043_020b3234` (48 bytes)
- `func_ov043_020b3264` (44 bytes)
- `func_ov043_020b50f8` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #52
