### PR TITLE
Decompile 3 functions in ov062

### DIFF
--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -8,6 +8,14 @@ libs/nitro/snd/calls/SNDi_UnlockMutex_ov062_0x020b5a20.c:
     complete
     .text       start:0x020b5a20 end:0x020b5a34
 
+src/overlays/ov062/calls/func_ov062_020b5a34.c:
+    complete
+    .text       start:0x020b5a34 end:0x020b5a64
+
+src/overlays/ov062/calls/func_ov062_020b5a64.c:
+    complete
+    .text       start:0x020b5a64 end:0x020b5a90
+
 src/overlays/ov062/calls/func_ov062_020b5d1c.c:
     complete
     .text       start:0x020b5d1c end:0x020b5d44
@@ -35,6 +43,10 @@ src/overlays/ov062/calls/func_ov062_020b7320.c:
 src/overlays/ov062/calls/func_ov062_020b7344.c:
     complete
     .text       start:0x020b7344 end:0x020b7360
+
+src/overlays/ov062/calls/func_ov062_020b78f8.c:
+    complete
+    .text       start:0x020b78f8 end:0x020b7920
 
 src/overlays/ov062/calls/func_ov062_020b7a74.c:
     complete

--- a/src/overlays/ov062/calls/func_ov062_020b5a34.c
+++ b/src/overlays/ov062/calls/func_ov062_020b5a34.c
@@ -1,0 +1,15 @@
+extern void *NNSi_FndGetCurrentRootHeap(void);
+extern void func_ov062_020b5a90(void *arg0);
+extern void func_ov062_020b5fdc(void *heap);
+extern void func_ov062_020b6f34(void *heap);
+extern void func_ov022_020a4798(void *heap, int nId, int nArg2);
+extern void *func_ov022_0209fb24(void);
+
+void *func_ov062_020b5a34(void *arg0) {
+    void *heap = NNSi_FndGetCurrentRootHeap();
+    func_ov062_020b5a90(arg0);
+    func_ov062_020b5fdc(heap);
+    func_ov062_020b6f34(heap);
+    func_ov022_020a4798(heap, 0x4f, 0xc4);
+    return func_ov022_0209fb24;
+}

--- a/src/overlays/ov062/calls/func_ov062_020b5a64.c
+++ b/src/overlays/ov062/calls/func_ov062_020b5a64.c
@@ -1,0 +1,9 @@
+extern int NNSi_FndGetCurrentRootHeap();extern int func_ov062_020b6010();extern void func_ov062_020b6ffc();extern void func_ov062_020b62d0();extern void func_ov022_0209fab4();extern int data_ov062_020b80e0;
+void func_ov062_020b5a64(void) {
+    int r = NNSi_FndGetCurrentRootHeap();
+    func_ov062_020b6010(r);
+    func_ov062_020b6ffc(r);
+    func_ov062_020b62d0(r);
+    func_ov022_0209fab4(r);
+    *(int *)&data_ov062_020b80e0 = 0;
+}

--- a/src/overlays/ov062/calls/func_ov062_020b78f8.c
+++ b/src/overlays/ov062/calls/func_ov062_020b78f8.c
@@ -1,0 +1,7 @@
+extern void func_0202aa9c(void *node);
+
+void func_ov062_020b78f8(char *p) {
+    if (*(int *)p != 1) return;
+    func_0202aa9c(p + 4);
+    func_0202aa9c(p + 0x10c);
+}


### PR DESCRIPTION
Closes #62.

3 functions in ov062 as matching C:

- `func_ov062_020b5a34` (48 bytes)
- `func_ov062_020b5a64` (44 bytes)
- `func_ov062_020b78f8` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #62
