### PR TITLE
Decompile 3 functions in ov105

### DIFF
--- a/config/arm9/overlays/ov105/delinks.txt
+++ b/config/arm9/overlays/ov105/delinks.txt
@@ -3,6 +3,10 @@
     .data       start:0x020bfa00 end:0x020bfa20 kind:data align:32
     .bss        start:0x020bfa20 end:0x020c0680 kind:bss align:32
 
+src/overlays/ov105/calls/func_ov105_020bcc20.c:
+    complete
+    .text       start:0x020bcc20 end:0x020bcc4c
+
 src/overlays/ov105/calls/func_ov105_020bce30.c:
     complete
     .text       start:0x020bce30 end:0x020bcea0
@@ -95,6 +99,10 @@ src/overlays/ov105/calls/func_ov105_020be850.c:
     complete
     .text       start:0x020be850 end:0x020be880
 
+src/overlays/ov105/calls/func_ov105_020be880.c:
+    complete
+    .text       start:0x020be880 end:0x020be8b0
+
 src/overlays/ov105/calls/func_ov105_020be8b0.c:
     complete
     .text       start:0x020be8b0 end:0x020be8d8
@@ -122,6 +130,10 @@ src/overlays/ov105/calls/func_ov105_020becc4.c:
 src/overlays/ov105/calls/func_ov105_020bef44.c:
     complete
     .text       start:0x020bef44 end:0x020bef74
+
+src/overlays/ov105/calls/func_ov105_020bef74.c:
+    complete
+    .text       start:0x020bef74 end:0x020befa8
 
 src/overlays/ov105/calls/func_ov105_020befe0.c:
     complete

--- a/src/overlays/ov105/calls/func_ov105_020bcc20.c
+++ b/src/overlays/ov105/calls/func_ov105_020bcc20.c
@@ -1,0 +1,11 @@
+extern int func_ov105_020bcc4c(int a0, int a1, int a2);
+extern int data_ov105_020bfa20;
+
+int func_ov105_020bcc20(int a0, int a1) {
+    int result = func_ov105_020bcc4c(a0, a1, 0xf00);
+    if (result != 0) {
+        return result;
+    }
+    *(unsigned short *)(*(char **)((char *)&data_ov105_020bfa20 + 4) + 0x16) = 0;
+    return result;
+}

--- a/src/overlays/ov105/calls/func_ov105_020be880.c
+++ b/src/overlays/ov105/calls/func_ov105_020be880.c
@@ -1,0 +1,17 @@
+extern void func_ov105_020be4ac(unsigned int id);
+extern int func_ov105_020be8b0(void);
+extern void func_ov105_020bf90c(void);
+
+/* If the request carries a target id, apply it and finish; otherwise try the fallback and only
+ * finish when it declines. */
+void func_ov105_020be880(int req) {
+    if (*(unsigned short *)(req + 2) != 0) {
+        func_ov105_020be4ac(*(unsigned short *)(req + 2));
+        func_ov105_020bf90c();
+        return;
+    }
+    if (func_ov105_020be8b0() != 0) {
+        return;
+    }
+    func_ov105_020bf90c();
+}

--- a/src/overlays/ov105/calls/func_ov105_020bef74.c
+++ b/src/overlays/ov105/calls/func_ov105_020bef74.c
@@ -1,0 +1,18 @@
+extern void func_ov105_020be4ac(unsigned int id);
+extern void func_ov105_020bf928(void);
+extern int func_ov105_020befa8(void);
+extern void func_ov105_020be49c(int state);
+
+/* If the request carries a target id, apply it and finish; otherwise try the fallback and only
+ * go to state 9 when it declines. */
+void func_ov105_020bef74(int req) {
+    if (*(unsigned short *)(req + 2) != 0) {
+        func_ov105_020be4ac(*(unsigned short *)(req + 2));
+        func_ov105_020bf928();
+        return;
+    }
+    if (func_ov105_020befa8() != 0) {
+        return;
+    }
+    func_ov105_020be49c(9);
+}


### PR DESCRIPTION
Closes #84.

3 functions in ov105 as matching C:

- `func_ov105_020bcc20` (44 bytes)
- `func_ov105_020be880` (48 bytes)
- `func_ov105_020bef74` (52 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #84
