### PR TITLE
Decompile 3 functions in ov106

### DIFF
--- a/config/arm9/overlays/ov106/delinks.txt
+++ b/config/arm9/overlays/ov106/delinks.txt
@@ -4,6 +4,14 @@
     .data       start:0x020b8aa0 end:0x020b8b60 kind:data align:32
     .bss        start:0x020b8b60 end:0x020b8b80 kind:bss align:32
 
+src/overlays/ov106/calls/func_ov106_020b75c0.c:
+    complete
+    .text       start:0x020b75c0 end:0x020b75e4
+
+src/overlays/ov106/calls/func_ov106_020b7728.c:
+    complete
+    .text       start:0x020b7728 end:0x020b7758
+
 src/overlays/ov106/calls/func_ov106_020b7758.c:
     complete
     .text       start:0x020b7758 end:0x020b7792
@@ -11,6 +19,10 @@ src/overlays/ov106/calls/func_ov106_020b7758.c:
 src/overlays/ov106/calls/func_ov106_020b7794.c:
     complete
     .text       start:0x020b7794 end:0x020b77b4
+
+src/overlays/ov106/calls/func_ov106_020b8108.c:
+    complete
+    .text       start:0x020b8108 end:0x020b8130
 
 src/overlays/ov106/calls/func_ov106_020b8130.c:
     complete

--- a/src/overlays/ov106/calls/func_ov106_020b75c0.c
+++ b/src/overlays/ov106/calls/func_ov106_020b75c0.c
@@ -1,0 +1,9 @@
+extern void *data_ov106_020b8b60;
+extern void func_ov106_020b75e4(void);
+
+void *func_ov106_020b75c0(void) {
+    if ((*(unsigned short *)((char *)data_ov106_020b8b60 + 0x8e44) & 2) != 0) {
+        return (void *)func_ov106_020b75e4;
+    }
+    return 0;
+}

--- a/src/overlays/ov106/calls/func_ov106_020b7728.c
+++ b/src/overlays/ov106/calls/func_ov106_020b7728.c
@@ -1,0 +1,10 @@
+extern int data_ov106_020b8b60;
+extern void func_ov002_02074024(int index, int flag);
+
+int func_ov106_020b7728(void) {
+    int active = *(int *)(data_ov106_020b8b60 + 0x8e48);
+
+    func_ov002_02074024(0, active == 0);
+    func_ov002_02074024(1, 0);
+    return 0;
+}

--- a/src/overlays/ov106/calls/func_ov106_020b8108.c
+++ b/src/overlays/ov106/calls/func_ov106_020b8108.c
@@ -1,0 +1,8 @@
+extern void OS_SPrintf(char *dst, const char *fmt);
+extern int data_ov106_020b8b60;
+
+void func_ov106_020b8108(const char *fmt) {
+    char *base = (char *)*(int *)&data_ov106_020b8b60;
+    *(unsigned short *)(base + 0x8e44) |= 2;
+    OS_SPrintf((char *)*(int *)&data_ov106_020b8b60 + 0x8e50, fmt);
+}


### PR DESCRIPTION
Closes #86.

3 functions in ov106 as matching C:

- `func_ov106_020b75c0` (36 bytes)
- `func_ov106_020b7728` (48 bytes)
- `func_ov106_020b8108` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #86
