### PR TITLE
Decompile 1 function in ov119

### DIFF
--- a/config/arm9/overlays/ov119/delinks.txt
+++ b/config/arm9/overlays/ov119/delinks.txt
@@ -52,6 +52,10 @@ src/overlays/ov119/calls/func_ov119_020cd144.c:
     complete
     .text       start:0x020cd144 end:0x020cd1ac
 
+src/overlays/ov119/calls/func_ov119_020cd1ac.c:
+    complete
+    .text       start:0x020cd1ac end:0x020cd224
+
 src/overlays/ov119/calls/func_ov119_020cd224.c:
     complete
     .text       start:0x020cd224 end:0x020cd314

--- a/src/overlays/ov119/calls/func_ov119_020cd1ac.c
+++ b/src/overlays/ov119/calls/func_ov119_020cd1ac.c
@@ -1,0 +1,35 @@
+/* Publish the landing pose: only while bit 0 of the hw60 low byte is set, send the anchor point
+ * -- the vector at state[0x12] with y raised by 0x1200 -- to the render hook and latch the pending
+ * action byte from +0x1c9 into +0x1c7.
+ *
+ * Matched byte-exact 2026-07-23, closing an old park. The anchor is built with the SDK's
+ * `static inline VEC_Set`, not with three field assignments: the three arguments are three
+ * adjacent loads that mwcc groups into one ldm, and the inline body is three separate stores.
+ * Written as `v.x = p[0]; v.y = p[1] + 0x1200; v.z = p[2];` the loads stay split and nine
+ * instructions come out different.
+ *
+ * One of three byte-identical siblings. */
+struct vec3 { int x, y, z; };
+struct hw60 { unsigned short lo : 8, hi : 8; };
+static inline void VEC_Set(struct vec3 *v, int x, int y, int z) {
+    v->x = x;
+    v->y = y;
+    v->z = z;
+}
+
+extern void func_ov107_020c5c54(int obj, struct vec3 *v);
+extern void func_0203c634(int self, int idx, int cb);
+
+void func_ov119_020cd1ac(int *self) {
+    int *state = (int *)self[1];
+    struct vec3 v;
+
+    if ((((struct hw60 *)(*state + 0x60))->lo & 1) == 0) {
+        return;
+    }
+    { struct vec3 *p = (struct vec3 *)state[0x12];
+      VEC_Set(&v, p->x, p->y + 0x1200, p->z); }
+    func_ov107_020c5c54(*state, &v);
+    *(char *)(*state + 0x1c7) = *(signed char *)(*state + 0x1c9);
+    func_0203c634((int)self, *(signed char *)((int)self + 0x20), 0);
+}


### PR DESCRIPTION
Closes #90.

One function in ov119 as matching C:

- `func_ov119_020cd1ac` (120 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #90
