### PR TITLE
Decompile 5 functions in ov146

### DIFF
--- a/config/arm9/overlays/ov146/delinks.txt
+++ b/config/arm9/overlays/ov146/delinks.txt
@@ -16,6 +16,14 @@ src/overlays/ov146/calls/func_ov146_020cc2ac.c:
     complete
     .text       start:0x020cc2ac end:0x020cc2f4
 
+src/overlays/ov146/calls/func_ov146_020cc2f4.c:
+    complete
+    .text       start:0x020cc2f4 end:0x020cc328
+
+src/overlays/ov146/calls/func_ov146_020cc328.c:
+    complete
+    .text       start:0x020cc328 end:0x020cc35c
+
 src/overlays/ov146/calls/func_ov146_020cc508.c:
     complete
     .text       start:0x020cc508 end:0x020cc570
@@ -104,6 +112,10 @@ src/overlays/ov146/calls/func_ov146_020ce2b4.c:
     complete
     .text       start:0x020ce2b4 end:0x020ce2d0
 
+src/overlays/ov146/calls/func_ov146_020ce2d0.c:
+    complete
+    .text       start:0x020ce2d0 end:0x020ce308
+
 src/overlays/ov146/calls/func_ov146_020ce308.c:
     complete
     .text       start:0x020ce308 end:0x020ce344
@@ -111,6 +123,10 @@ src/overlays/ov146/calls/func_ov146_020ce308.c:
 src/overlays/ov146/calls/func_ov146_020ce514.c:
     complete
     .text       start:0x020ce514 end:0x020ce538
+
+src/overlays/ov146/calls/func_ov146_020ce538.c:
+    complete
+    .text       start:0x020ce538 end:0x020ce564
 
 src/overlays/ov146/calls/func_ov146_020ce608.c:
     complete
@@ -167,6 +183,10 @@ src/overlays/ov146/calls/func_ov146_020cee30.c:
 src/overlays/ov146/auto/func_ov146_020cf0cc.c:
     complete
     .text       start:0x020cf0cc end:0x020cf134
+
+src/overlays/ov146/calls/func_ov146_020cf134.c:
+    complete
+    .text       start:0x020cf134 end:0x020cf168
 
 src/overlays/ov146/calls/func_ov146_020cf200.c:
     complete

--- a/src/overlays/ov146/calls/func_ov146_020cc2f4.c
+++ b/src/overlays/ov146/calls/func_ov146_020cc2f4.c
@@ -1,0 +1,10 @@
+/* func_ov146_020cc2f4 -- hand both sub-objects (+0x3b8, +0x3bc) to the visitor and then run the
+ * base pass. The visitor takes (arg, object), not the other way round. */
+extern void func_ov107_020c2b20(int arg, int obj);
+extern void func_ov107_020c7b70(int obj, int arg);
+
+void func_ov146_020cc2f4(int obj, int arg) {
+    func_ov107_020c2b20(arg, *(int *)(obj + 0x3b8));
+    func_ov107_020c2b20(arg, *(int *)(obj + 0x3bc));
+    func_ov107_020c7b70(obj, arg);
+}

--- a/src/overlays/ov146/calls/func_ov146_020cc328.c
+++ b/src/overlays/ov146/calls/func_ov146_020cc328.c
@@ -1,0 +1,10 @@
+/* func_ov146_020cc328 -- hand both sub-objects (+0x3b8, +0x3bc) to the visitor and then run the
+ * base pass. The visitor takes (arg, object), not the other way round. */
+extern void func_ov107_020c2b38(int arg, int obj);
+extern void func_ov107_020c7c1c(int obj, int arg);
+
+void func_ov146_020cc328(int obj, int arg) {
+    func_ov107_020c2b38(arg, *(int *)(obj + 0x3b8));
+    func_ov107_020c2b38(arg, *(int *)(obj + 0x3bc));
+    func_ov107_020c7c1c(obj, arg);
+}

--- a/src/overlays/ov146/calls/func_ov146_020ce2d0.c
+++ b/src/overlays/ov146/calls/func_ov146_020ce2d0.c
@@ -1,0 +1,10 @@
+struct v3 { int x, y, z; };
+
+extern int func_ov146_020ce694(int a, struct v3 v);
+
+int func_ov146_020ce2d0(int param_1, struct v3 param_2) {
+    if (*(int *)(param_1 + 0x50) == 1) {
+        return func_ov146_020ce694(*(int *)(param_1 + 0x214), param_2);
+    }
+    return param_1;
+}

--- a/src/overlays/ov146/calls/func_ov146_020ce538.c
+++ b/src/overlays/ov146/calls/func_ov146_020ce538.c
@@ -1,0 +1,10 @@
+extern void func_ov107_020c6980(void *obj, int arg2);
+
+void func_ov146_020ce538(char *obj, int arg2) {
+    if (*(unsigned char *)(*(char **)(obj + 0x3b4) + 0x1c4) & 2) {
+        if (*(unsigned short *)(obj + 0x1ac) & 0x10) {
+            arg2 = 0;
+        }
+    }
+    func_ov107_020c6980(obj, arg2);
+}

--- a/src/overlays/ov146/calls/func_ov146_020cf134.c
+++ b/src/overlays/ov146/calls/func_ov146_020cf134.c
@@ -1,0 +1,10 @@
+extern void func_ov107_020c7a90(int self, int node, int arg3);
+
+void func_ov146_020cf134(int self, int node, int arg3) {
+    if (*(unsigned char *)(node + 2) == 0) {
+        *(signed char *)(node + 0x24) =
+            (signed char)((*(int *)(*(int *)(self + 0x384) + 0x5c) << 30) >> 31);
+        *(signed char *)(node + 0x25) = *(int *)(self + 0x38c);
+    }
+    func_ov107_020c7a90(self, node, arg3);
+}


### PR DESCRIPTION
Closes #92.

5 functions in ov146 as matching C:

- `func_ov146_020cc2f4` (52 bytes)
- `func_ov146_020cc328` (52 bytes)
- `func_ov146_020ce2d0` (56 bytes)
- `func_ov146_020ce538` (44 bytes)
- `func_ov146_020cf134` (52 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #92
