### PR TITLE
Decompile 2 functions in ov160

### DIFF
--- a/config/arm9/overlays/ov160/delinks.txt
+++ b/config/arm9/overlays/ov160/delinks.txt
@@ -20,6 +20,14 @@ src/overlays/ov160/calls/func_ov160_020cc2e0.c:
     complete
     .text       start:0x020cc2e0 end:0x020cc39c
 
+src/overlays/ov160/calls/func_ov160_020cc578.c:
+    complete
+    .text       start:0x020cc578 end:0x020cc5a0
+
+src/overlays/ov160/calls/func_ov160_020cc5a0.c:
+    complete
+    .text       start:0x020cc5a0 end:0x020cc5c8
+
 src/overlays/ov160/calls/func_ov160_020cc764.c:
     complete
     .text       start:0x020cc764 end:0x020cc7c0

--- a/src/overlays/ov160/calls/func_ov160_020cc578.c
+++ b/src/overlays/ov160/calls/func_ov160_020cc578.c
@@ -1,0 +1,7 @@
+extern void func_ov107_020c2b20(void *a, int v);
+extern void func_ov107_020c7b70(void *a, void *b);
+
+void func_ov160_020cc578(char *a, void *b) {
+    func_ov107_020c2b20(b, *(int *)(a + 0x3a4));
+    func_ov107_020c7b70(a, b);
+}

--- a/src/overlays/ov160/calls/func_ov160_020cc5a0.c
+++ b/src/overlays/ov160/calls/func_ov160_020cc5a0.c
@@ -1,0 +1,7 @@
+extern void func_ov107_020c2b38(void *a, int v);
+extern void func_ov107_020c7c1c(void *a, void *b);
+
+void func_ov160_020cc5a0(char *a, void *b) {
+    func_ov107_020c2b38(b, *(int *)(a + 0x3a4));
+    func_ov107_020c7c1c(a, b);
+}


### PR DESCRIPTION
Closes #98.

2 functions in ov160 as matching C:

- `func_ov160_020cc578` (40 bytes)
- `func_ov160_020cc5a0` (40 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #98
