### PR TITLE
Decompile 1 function in ov213

### DIFF
--- a/config/arm9/overlays/ov213/delinks.txt
+++ b/config/arm9/overlays/ov213/delinks.txt
@@ -144,6 +144,10 @@ src/overlays/ov213/calls/func_ov213_020d1824.c:
     complete
     .text       start:0x020d1824 end:0x020d1864
 
+src/overlays/ov213/calls/func_ov213_020d1864.c:
+    complete
+    .text       start:0x020d1864 end:0x020d18a4
+
 src/overlays/ov213/auto/func_ov213_020d18a4.c:
     complete
     .text       start:0x020d18a4 end:0x020d1908

--- a/src/overlays/ov213/calls/func_ov213_020d1864.c
+++ b/src/overlays/ov213/calls/func_ov213_020d1864.c
@@ -1,0 +1,8 @@
+typedef struct { int w[11]; } Blk44;
+
+extern void func_ov107_020c6980(char *self, int a);
+
+void func_ov213_020d1864(char *self, int a) {
+    *(Blk44 *)(*(char **)(self + 0x38c) + 0x10) = *(Blk44 *)(self + 0xa0);
+    func_ov107_020c6980(self, a);
+}


### PR DESCRIPTION
Closes #112.

One function in ov213 as matching C:

- `func_ov213_020d1864` (64 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #112
