### PR TITLE
Decompile 2 functions in ov218

### DIFF
--- a/config/arm9/overlays/ov218/delinks.txt
+++ b/config/arm9/overlays/ov218/delinks.txt
@@ -28,6 +28,10 @@ src/overlays/ov218/calls/func_ov218_020cc3b8.c:
     complete
     .text       start:0x020cc3b8 end:0x020cc3f4
 
+src/overlays/ov218/calls/func_ov218_020cc4ec.c:
+    complete
+    .text       start:0x020cc4ec end:0x020cc528
+
 src/overlays/ov218/calls/func_ov218_020cc528.c:
     complete
     .text       start:0x020cc528 end:0x020cc560
@@ -115,6 +119,10 @@ src/overlays/ov218/calls/func_ov218_020cded0.c:
 src/overlays/ov218/calls/func_ov218_020ce040.c:
     complete
     .text       start:0x020ce040 end:0x020ce07c
+
+src/overlays/ov218/calls/func_ov218_020ce224.c:
+    complete
+    .text       start:0x020ce224 end:0x020ce25c
 
 src/overlays/ov218/calls/func_ov218_020ce25c.c:
     complete

--- a/src/overlays/ov218/calls/func_ov218_020cc4ec.c
+++ b/src/overlays/ov218/calls/func_ov218_020cc4ec.c
@@ -1,0 +1,13 @@
+/* func_ov218_020cc4ec -- release the held sub-object at +0x3e8 (unless the actor's kind byte is 3
+ * or nothing is held) and then run the base teardown. Sibling of func_ov245_020d0abc, which does
+ * the same for +0x3a0 and has no base call. */
+extern void func_0203c650(int a, int b);
+extern void func_ov107_020c7ca4(int self);
+
+void func_ov218_020cc4ec(int self) {
+    if (*(signed char *)(self + 0x1c6) != 3 && *(int *)(self + 0x3e8) != 0) {
+        func_0203c650(*(int *)(self + 0x3c), *(int *)(self + 0x3e8));
+        *(int *)(self + 0x3e8) = 0;
+    }
+    func_ov107_020c7ca4(self);
+}

--- a/src/overlays/ov218/calls/func_ov218_020ce224.c
+++ b/src/overlays/ov218/calls/func_ov218_020ce224.c
@@ -1,0 +1,16 @@
+extern int func_0203c7e8();
+extern int func_ov107_020c68ec();
+
+struct S {
+    char pad[0x39c];
+    int arr[2][2];
+};
+
+int func_ov218_020ce224(struct S *r5) {
+    int i;
+    func_0203c7e8(*(int *)((char *)r5 + 0x384));
+    for (i = 0; i < 2; i++) {
+        func_0203c7e8(r5->arr[i][0]);
+    }
+    return func_ov107_020c68ec(r5);
+}


### PR DESCRIPTION
Closes #114.

2 functions in ov218 as matching C:

- `func_ov218_020cc4ec` (60 bytes)
- `func_ov218_020ce224` (56 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #114
