### PR TITLE
Decompile 1 function in ov226

### DIFF
--- a/config/arm9/overlays/ov226/delinks.txt
+++ b/config/arm9/overlays/ov226/delinks.txt
@@ -212,6 +212,10 @@ src/overlays/ov226/calls/func_ov226_020d4140.c:
     complete
     .text       start:0x020d4140 end:0x020d4178
 
+src/overlays/ov226/auto/func_ov226_020d429c.c:
+    complete
+    .text       start:0x020d429c end:0x020d42d8
+
 src/overlays/ov226/calls/func_ov226_020d42d8.c:
     complete
     .text       start:0x020d42d8 end:0x020d4334

--- a/src/overlays/ov226/auto/func_ov226_020d429c.c
+++ b/src/overlays/ov226/auto/func_ov226_020d429c.c
@@ -1,0 +1,11 @@
+struct Vec3 { int x, y, z; };
+
+extern struct Vec3 data_02041dc8;
+
+void func_ov226_020d429c(void *this_, int val, int unused2, int unused3, int unused4, struct Vec3 vec) {
+    void *owner = *(void **)this_;
+    *((signed char *)owner + 0x1c7) = 1;
+    *(int *)((char *)this_ + 0x44) = val;
+    *(struct Vec3 *)((char *)this_ + 0x24) = vec;
+    *(struct Vec3 *)((char *)this_ + 0x18) = data_02041dc8;
+}


### PR DESCRIPTION
Closes #116.

One function in ov226 as matching C:

- `func_ov226_020d429c` (60 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #116
