### PR TITLE
Decompile 3 functions in ov227

### DIFF
--- a/config/arm9/overlays/ov227/delinks.txt
+++ b/config/arm9/overlays/ov227/delinks.txt
@@ -28,6 +28,14 @@ src/overlays/ov227/calls/func_ov227_020d027c.c:
     complete
     .text       start:0x020d027c end:0x020d02a0
 
+src/overlays/ov227/calls/func_ov227_020d02a0.c:
+    complete
+    .text       start:0x020d02a0 end:0x020d02e4
+
+src/overlays/ov227/calls/func_ov227_020d02e4.c:
+    complete
+    .text       start:0x020d02e4 end:0x020d0328
+
 src/overlays/ov227/calls/func_ov227_020d05d4.c:
     complete
     .text       start:0x020d05d4 end:0x020d0640
@@ -187,6 +195,10 @@ src/overlays/ov227/calls/func_ov227_020d3bc8.c:
 src/overlays/ov227/calls/func_ov227_020d3c5c.c:
     complete
     .text       start:0x020d3c5c end:0x020d3c8c
+
+src/overlays/ov227/calls/func_ov227_020d3c8c.c:
+    complete
+    .text       start:0x020d3c8c end:0x020d3da0
 
 src/overlays/ov227/calls/func_ov227_020d3e0c.c:
     complete

--- a/src/overlays/ov227/calls/func_ov227_020d02a0.c
+++ b/src/overlays/ov227/calls/func_ov227_020d02a0.c
@@ -1,0 +1,15 @@
+extern int func_ov107_020c2b20();
+extern int func_ov107_020c7b70();
+
+int func_ov227_020d02a0(int *r0, int r1)
+{
+    int i;
+
+    for (i = 0; i < 10; i++) {
+        int v = r0[i + 0xfb];
+        if (v) {
+            func_ov107_020c2b20(r1, v);
+        }
+    }
+    return func_ov107_020c7b70(r0, r1);
+}

--- a/src/overlays/ov227/calls/func_ov227_020d02e4.c
+++ b/src/overlays/ov227/calls/func_ov227_020d02e4.c
@@ -1,0 +1,15 @@
+extern int func_ov107_020c2b38();
+extern int func_ov107_020c7c1c();
+
+int func_ov227_020d02e4(int *r0, int r1)
+{
+    int i;
+
+    for (i = 0; i < 10; i++) {
+        int v = r0[i + 0xfb];
+        if (v) {
+            func_ov107_020c2b38(r1, v);
+        }
+    }
+    return func_ov107_020c7c1c(r0, r1);
+}

--- a/src/overlays/ov227/calls/func_ov227_020d3c8c.c
+++ b/src/overlays/ov227/calls/func_ov227_020d3c8c.c
@@ -1,0 +1,71 @@
+extern int VEC_Subtract();
+extern int func_020050b4();
+extern int func_01ff8d18();
+extern int func_01ffa724();
+extern int MTX_RotY33_();
+extern int MTX_MultVec33();
+extern int func_0203c634();
+extern short data_0203d210[];
+
+struct sub {
+    int f0;       /* +0x00 */
+    int pad04;    /* +0x04 */
+    int f8;       /* +0x08 */
+    char pad0c[0x80 - 0x0c];
+    int f80;      /* +0x80 */
+    char pad84[0x190 - 0x84];
+    char f190[1]; /* +0x190 */
+    char pad191[0x1c7 - 0x191];
+    unsigned char f1c7; /* +0x1c7 */
+    char pad1c8[0x414 - 0x1c8];
+    int f3fc;     /* +0x414 */
+};
+
+struct mid {
+    struct sub *f0;   /* +0x00 */
+    int pad04;        /* +0x04 */
+    int f8;           /* +0x08 */
+    char pad0c[0x14 - 0x0c];
+    char f14[1];      /* +0x14 */
+    char pad15[0x58 - 0x15];
+    int f58;          /* +0x58 */
+    char pad5c[0x78 - 0x5c];
+    int f78;          /* +0x78 */
+};
+
+struct top {
+    char pad0[0x04];
+    struct mid *f4;   /* +0x04 */
+    char pad08[0x20 - 0x08];
+    signed char f20;  /* +0x20 */
+};
+
+void func_ov227_020d3c8c(struct top *a)
+{
+    struct mid *r4 = a->f4;
+    int s24[3];
+    int s0[9];
+    int diff;
+
+    struct sub *sub0;
+
+    VEC_Subtract((char *)r4->f0 + 0x190, r4->f8, s24);
+    r4->f58 = func_020050b4(s24[0], s24[2]);
+    sub0 = r4->f0;
+    diff = func_01ff8d18(s24, s24) - sub0->f80;
+
+    if (r4->f78 != 0) {
+        func_01ffa724(0x100, s24, r4->f14);
+    } else {
+        long long p = (long long)r4->f58 * 0x28be60db9391LL + 0x80000000000LL;
+        int h = (int)(p >> 32);
+        int idx = (int)((unsigned)h << 4 >> 16) >> 4;
+        MTX_RotY33_(s0, data_0203d210[idx * 2], data_0203d210[idx * 2 + 1]);
+        MTX_MultVec33(r4->f0->f3fc + 0x2c, s0, r4->f14);
+    }
+
+    if (diff < 0x2000) {
+        r4->f0->f1c7 = 2;
+        func_0203c634(a, a->f20, 0);
+    }
+}


### PR DESCRIPTION
Closes #118.

3 functions in ov227 as matching C:

- `func_ov227_020d02a0` (68 bytes)
- `func_ov227_020d02e4` (68 bytes)
- `func_ov227_020d3c8c` (276 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #118
