### PR TITLE
Decompile 2 functions in ov235

### DIFF
--- a/config/arm9/overlays/ov235/delinks.txt
+++ b/config/arm9/overlays/ov235/delinks.txt
@@ -16,6 +16,10 @@ src/overlays/ov235/calls/func_ov235_020cc494.c:
     complete
     .text       start:0x020cc494 end:0x020cc51c
 
+src/overlays/ov235/calls/func_ov235_020cc51c.c:
+    complete
+    .text       start:0x020cc51c end:0x020cc554
+
 libs/nitro/wm/calls/WM_EndKeySharing_0x020cc8a0.c:
     complete
     .text       start:0x020cc8a0 end:0x020cc8ac
@@ -119,6 +123,10 @@ src/overlays/ov235/calls/func_ov235_020d1e5c.c:
 src/overlays/ov235/calls/func_ov235_020d2084.c:
     complete
     .text       start:0x020d2084 end:0x020d20a4
+
+src/overlays/ov235/calls/func_ov235_020d20a4.c:
+    complete
+    .text       start:0x020d20a4 end:0x020d2104
 
 src/overlays/ov235/auto/func_ov235_020d21a8.c:
     complete

--- a/src/overlays/ov235/calls/func_ov235_020cc51c.c
+++ b/src/overlays/ov235/calls/func_ov235_020cc51c.c
@@ -1,0 +1,10 @@
+extern void func_ov107_020c9ec8(int node, int flag);
+extern void func_ov107_020c6980(void *a, int flag);
+
+void func_ov235_020cc51c(char *a, int b) {
+    if (*(unsigned short *)(a + 0x1ac) & 2) {
+        b = 0;
+    }
+    func_ov107_020c9ec8(*(int *)(a + 0x3a8), b);
+    func_ov107_020c6980(a, b);
+}

--- a/src/overlays/ov235/calls/func_ov235_020d20a4.c
+++ b/src/overlays/ov235/calls/func_ov235_020d20a4.c
@@ -1,0 +1,20 @@
+/* func_ov235_020d20a4 -- spawn the 0x10-byte task that drives this reaction (step
+ * func_ov235_020d2104, completion func_ov235_020d21a8, priority 0x64) and seed its three-word
+ * payload with (self, a, b). RETURNS the task handle: the ROM leaves r0 untouched from the spawn
+ * call to the `pop`, and declaring the function `void` frees r0 so mwcc reuses it for the payload
+ * pointer -- one register off, nothing else.
+ * The payload pointer is re-read from the stack before each store because its address escaped into
+ * the spawn call, so the stores could alias it; that is the ROM's three `ldr r1,[sp,#8]`. */
+extern int func_0203c5c0(int owner, int a, int b, void *step, void *done, int **out);
+extern void func_ov235_020d21a8(void);
+extern void func_ov235_020d2104(void);
+
+int func_ov235_020d20a4(int obj, int a, int b) {
+    int *out;
+    int r = func_0203c5c0(*(int *)(obj + 0x3c), 0x64, 0x10, (void *)func_ov235_020d2104,
+                          (void *)func_ov235_020d21a8, &out);
+    out[0] = obj;
+    out[1] = a;
+    out[2] = b;
+    return r;
+}


### PR DESCRIPTION
Closes #120.

2 functions in ov235 as matching C:

- `func_ov235_020cc51c` (56 bytes)
- `func_ov235_020d20a4` (96 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #120
