### PR TITLE
Decompile 5 functions in ov237

### DIFF
--- a/config/arm9/overlays/ov237/delinks.txt
+++ b/config/arm9/overlays/ov237/delinks.txt
@@ -28,6 +28,18 @@ src/overlays/ov237/auto/func_ov237_020cc840.c:
     complete
     .text       start:0x020cc840 end:0x020cc8a8
 
+src/overlays/ov237/calls/func_ov237_020ccef0.c:
+    complete
+    .text       start:0x020ccef0 end:0x020ccf2c
+
+src/overlays/ov237/calls/func_ov237_020ccf2c.c:
+    complete
+    .text       start:0x020ccf2c end:0x020ccf68
+
+src/overlays/ov237/calls/func_ov237_020ccfb4.c:
+    complete
+    .text       start:0x020ccfb4 end:0x020ccfe8
+
 src/overlays/ov237/calls/func_ov237_020cd0b0.c:
     complete
     .text       start:0x020cd0b0 end:0x020cd12c
@@ -35,6 +47,10 @@ src/overlays/ov237/calls/func_ov237_020cd0b0.c:
 src/overlays/ov237/auto/func_ov237_020cd550.c:
     complete
     .text       start:0x020cd550 end:0x020cd554
+
+src/overlays/ov237/calls/func_ov237_020cdb50.c:
+    complete
+    .text       start:0x020cdb50 end:0x020cdbe4
 
 src/overlays/ov237/calls/func_ov237_020ce2ac.c:
     complete
@@ -143,6 +159,10 @@ libs/nitro/wm/calls/WM_EndKeySharing_0x020d0ca0.c:
 src/overlays/ov237/calls/func_ov237_020d0cac.c:
     complete
     .text       start:0x020d0cac end:0x020d0cc8
+
+src/overlays/ov237/calls/func_ov237_020d0cc8.c:
+    complete
+    .text       start:0x020d0cc8 end:0x020d0d14
 
 src/overlays/ov237/calls/func_ov237_020d0d14.c:
     complete

--- a/src/overlays/ov237/calls/func_ov237_020ccef0.c
+++ b/src/overlays/ov237/calls/func_ov237_020ccef0.c
@@ -1,0 +1,15 @@
+/* Forward the sub-object at (obj)+0x3e0, and (if present) the one at +0x4a4, to the ov107
+ * callback dispatcher, then run the base ov107 attach for the pair. */
+extern void func_ov107_020c2b20(int obj, int arg1);
+extern void func_ov107_020c7b70(int obj, int arg1);
+
+void func_ov237_020ccef0(int param_1, int param_2) {
+    func_ov107_020c2b20(param_2, *(int *)(param_1 + 0x3e0));
+
+    int field_4a4 = *(int *)(param_1 + 0x4a4);
+    if (field_4a4 != 0) {
+        func_ov107_020c2b20(param_2, field_4a4);
+    }
+
+    func_ov107_020c7b70(param_1, param_2);
+}

--- a/src/overlays/ov237/calls/func_ov237_020ccf2c.c
+++ b/src/overlays/ov237/calls/func_ov237_020ccf2c.c
@@ -1,0 +1,15 @@
+/* Forward the sub-object at (obj)+0x3e0, and (if present) the one at +0x4a4, to the ov107
+ * callback dispatcher, then tail-call the base ov107 handler for the pair. */
+extern void func_ov107_020c2b38(int obj, int arg1);
+extern void func_ov107_020c7c1c(int obj, int arg1);
+
+void func_ov237_020ccf2c(int param_1, int param_2) {
+    func_ov107_020c2b38(param_2, *(int *)(param_1 + 0x3e0));
+
+    int field_4a4 = *(int *)(param_1 + 0x4a4);
+    if (field_4a4 != 0) {
+        func_ov107_020c2b38(param_2, field_4a4);
+    }
+
+    func_ov107_020c7c1c(param_1, param_2);
+}

--- a/src/overlays/ov237/calls/func_ov237_020ccfb4.c
+++ b/src/overlays/ov237/calls/func_ov237_020ccfb4.c
@@ -1,0 +1,11 @@
+extern void func_ov107_020c887c(int *self, int arg);
+
+typedef void (*func_ov237_020ccfb4_cb)(int *target, int arg);
+
+void func_ov237_020ccfb4(int *self, int arg) {
+    int *target = (int *)self[0x4a4 / 4];
+    if (target != 0 && target[0x1f0 / 4] != 0) {
+        ((func_ov237_020ccfb4_cb)target[0x1f0 / 4])(target, arg);
+    }
+    func_ov107_020c887c(self, arg);
+}

--- a/src/overlays/ov237/calls/func_ov237_020cdb50.c
+++ b/src/overlays/ov237/calls/func_ov237_020cdb50.c
@@ -1,0 +1,17 @@
+/* Rotate the input vector by the actor's heading: read the fixed-point angle from
+ * (*(param_2+4))+0x10, look up cos/sin in the shared trig table, build a Y-rotation
+ * matrix, transform the vector in place and copy it to *out. */
+extern void MTX_RotY33_(void *mtx, int cos, int sin);
+extern void MTX_MultVec33(int *out, void *mtx, int *in);
+extern const short data_0203d210[];
+struct Mtx33_020cca74 { int m[9]; };
+struct Vec3_020cca74 { int x, y, z; };
+void func_ov237_020cdb50(int *out, int param_2, int *vec) {
+    struct Mtx33_020cca74 mtx;
+    int v = *(int *)(*(int *)(param_2 + 4) + 0x10);
+    int angle = (int)(((unsigned)(((long long)(int)(unsigned)v * 0x28be60db9391LL
+                 + 0x80000000000LL) >> 0x20) << 4) >> 0x10) >> 4;
+    MTX_RotY33_(&mtx, data_0203d210[angle * 2], data_0203d210[angle * 2 + 1]);
+    MTX_MultVec33(vec, &mtx, vec);
+    *(struct Vec3_020cca74 *)out = *(struct Vec3_020cca74 *)vec;
+}

--- a/src/overlays/ov237/calls/func_ov237_020d0cc8.c
+++ b/src/overlays/ov237/calls/func_ov237_020d0cc8.c
@@ -1,0 +1,23 @@
+/* Message hook: only while the owner's state byte at +0x1c6 is 1 and the message carries
+ * both bit 0 and bit 4, moves the sub-state at +0x1c7 to 0 and reports handled.
+ *
+ * All three failure paths share one `return 0`, reached with a goto -- written as inline
+ * early returns mwcc duplicates the epilogue. */
+int func_ov237_020d0cc8(char *self, int unused, unsigned int *msg) {
+    char *o = *(char **)(*(char **)(self + 0x214));
+    unsigned short m;
+    if (*(signed char *)(o + 0x1c6) != 1) {
+        goto no;
+    }
+    m = (unsigned short)*msg;
+    if ((m & 1) == 0) {
+        goto no;
+    }
+    if ((m & 0x10) == 0) {
+        goto no;
+    }
+    o[0x1c7] = 0;
+    return 1;
+no:
+    return 0;
+}


### PR DESCRIPTION
Closes #122.

5 functions in ov237 as matching C:

- `func_ov237_020ccef0` (60 bytes)
- `func_ov237_020ccf2c` (60 bytes)
- `func_ov237_020ccfb4` (52 bytes)
- `func_ov237_020cdb50` (148 bytes)
- `func_ov237_020d0cc8` (76 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #122
