### PR TITLE
Decompile 4 functions in ov238

### DIFF
--- a/config/arm9/overlays/ov238/delinks.txt
+++ b/config/arm9/overlays/ov238/delinks.txt
@@ -20,6 +20,14 @@ src/overlays/ov238/calls/func_ov238_020d0104.c:
     complete
     .text       start:0x020d0104 end:0x020d0128
 
+src/overlays/ov238/calls/func_ov238_020d02f8.c:
+    complete
+    .text       start:0x020d02f8 end:0x020d0320
+
+src/overlays/ov238/calls/func_ov238_020d0320.c:
+    complete
+    .text       start:0x020d0320 end:0x020d0348
+
 src/overlays/ov238/calls/func_ov238_020d05dc.c:
     complete
     .text       start:0x020d05dc end:0x020d0638
@@ -52,6 +60,10 @@ src/overlays/ov238/calls/func_ov238_020d120c.c:
     complete
     .text       start:0x020d120c end:0x020d1258
 
+src/overlays/ov238/calls/func_ov238_020d1258.c:
+    complete
+    .text       start:0x020d1258 end:0x020d1290
+
 src/overlays/ov238/calls/func_ov238_020d14a4.c:
     complete
     .text       start:0x020d14a4 end:0x020d1510
@@ -83,6 +95,10 @@ src/overlays/ov238/calls/func_ov238_020d1e74.c:
 src/overlays/ov238/calls/func_ov238_020d1ea8.c:
     complete
     .text       start:0x020d1ea8 end:0x020d1f54
+
+src/overlays/ov238/calls/func_ov238_020d1fe0.c:
+    complete
+    .text       start:0x020d1fe0 end:0x020d2020
 
 src/overlays/ov238/calls/func_ov238_020d24d0.c:
     complete

--- a/src/overlays/ov238/calls/func_ov238_020d02f8.c
+++ b/src/overlays/ov238/calls/func_ov238_020d02f8.c
@@ -1,0 +1,7 @@
+extern void func_ov107_020c2b20(void *a, int v);
+extern void func_ov107_020c7b70(void *a, void *b);
+
+void func_ov238_020d02f8(char *a, void *b) {
+    func_ov107_020c2b20(b, *(int *)(a + 0x384));
+    func_ov107_020c7b70(a, b);
+}

--- a/src/overlays/ov238/calls/func_ov238_020d0320.c
+++ b/src/overlays/ov238/calls/func_ov238_020d0320.c
@@ -1,0 +1,7 @@
+extern void func_ov107_020c2b38(void *a, int v);
+extern void func_ov107_020c7c1c(void *a, void *b);
+
+void func_ov238_020d0320(char *a, void *b) {
+    func_ov107_020c2b38(b, *(int *)(a + 0x384));
+    func_ov107_020c7c1c(a, b);
+}

--- a/src/overlays/ov238/calls/func_ov238_020d1258.c
+++ b/src/overlays/ov238/calls/func_ov238_020d1258.c
@@ -1,0 +1,10 @@
+extern void func_ov238_020d0f54(int self, int param_2, int param_3, int param_4, void *cb);
+extern void func_ov238_020d1290(void);
+
+void func_ov238_020d1258(int param_1) {
+    int obj = *(int *)(param_1 + 4);
+    *(int *)(obj + 0x20) = 0;
+    *(signed char *)(obj + 0x31) = 2;
+    *(signed char *)(obj + 0x2d) = 2;
+    func_ov238_020d0f54(param_1, 0x12, 8, 0, (void *)&func_ov238_020d1290);
+}

--- a/src/overlays/ov238/calls/func_ov238_020d1fe0.c
+++ b/src/overlays/ov238/calls/func_ov238_020d1fe0.c
@@ -1,0 +1,11 @@
+extern void func_ov238_020d0f54(int self, int param_2, int param_3, int param_4, void *cb);
+extern void func_ov238_020d2020(void);
+
+void func_ov238_020d1fe0(int param_1) {
+    int obj = *(int *)(param_1 + 4);
+    *(signed char *)(obj + 0x2d) = 3;
+    *(signed char *)(obj + 0x2c) = 2;
+    *(int *)(obj + 0x20) = 0;
+    *(signed char *)(obj + 0x31) = 1;
+    func_ov238_020d0f54(param_1, 5, 1, 0, (void *)&func_ov238_020d2020);
+}


### PR DESCRIPTION
Closes #124.

4 functions in ov238 as matching C:

- `func_ov238_020d02f8` (40 bytes)
- `func_ov238_020d0320` (40 bytes)
- `func_ov238_020d1258` (56 bytes)
- `func_ov238_020d1fe0` (64 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #124
