### PR TITLE
Decompile 1 function in ov248

### DIFF
--- a/config/arm9/overlays/ov248/delinks.txt
+++ b/config/arm9/overlays/ov248/delinks.txt
@@ -216,6 +216,10 @@ src/overlays/ov248/calls/func_ov248_020d02b4.c:
     complete
     .text       start:0x020d02b4 end:0x020d02e8
 
+src/overlays/ov248/calls/func_ov248_020d03cc.c:
+    complete
+    .text       start:0x020d03cc end:0x020d03fc
+
 src/overlays/ov248/calls/func_ov248_020d0578.c:
     complete
     .text       start:0x020d0578 end:0x020d05d4

--- a/src/overlays/ov248/calls/func_ov248_020d03cc.c
+++ b/src/overlays/ov248/calls/func_ov248_020d03cc.c
@@ -1,0 +1,15 @@
+extern void func_0203c7e8(int obj);
+extern void func_ov107_020c68ec(int obj);
+
+typedef struct {
+    int field_00;
+    int field_04;
+} Pair8;
+
+void func_ov248_020d03cc(int obj) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        func_0203c7e8(((Pair8 *)obj)[i + 0x71].field_00);
+    }
+    func_ov107_020c68ec(obj);
+}


### PR DESCRIPTION
Closes #126.

One function in ov248 as matching C:

- `func_ov248_020d03cc` (48 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #126
