### PR TITLE
Decompile 3 functions in ov256

### DIFF
--- a/config/arm9/overlays/ov256/delinks.txt
+++ b/config/arm9/overlays/ov256/delinks.txt
@@ -24,6 +24,10 @@ src/overlays/ov256/calls/func_ov256_020ccce8.c:
     complete
     .text       start:0x020ccce8 end:0x020ccd54
 
+src/overlays/ov256/calls/func_ov256_020cd054.c:
+    complete
+    .text       start:0x020cd054 end:0x020cd0e8
+
 src/overlays/ov256/calls/func_ov256_020cd430.c:
     complete
     .text       start:0x020cd430 end:0x020cd740
@@ -156,6 +160,10 @@ src/overlays/ov256/calls/func_ov256_020d1068.c:
     complete
     .text       start:0x020d1068 end:0x020d108c
 
+src/overlays/ov256/calls/func_ov256_020d108c.c:
+    complete
+    .text       start:0x020d108c end:0x020d10b0
+
 src/overlays/ov256/calls/func_ov256_020d10b0.c:
     complete
     .text       start:0x020d10b0 end:0x020d10ec
@@ -183,6 +191,10 @@ src/overlays/ov256/calls/func_ov256_020d1564.c:
 src/overlays/ov256/calls/func_ov256_020d15c0.c:
     complete
     .text       start:0x020d15c0 end:0x020d166c
+
+src/overlays/ov256/calls/func_ov256_020d1900.c:
+    complete
+    .text       start:0x020d1900 end:0x020d1994
 
 src/overlays/ov256/calls/func_ov256_020d1ae8.c:
     complete

--- a/src/overlays/ov256/calls/func_ov256_020cd054.c
+++ b/src/overlays/ov256/calls/func_ov256_020cd054.c
@@ -1,0 +1,17 @@
+/* Rotate the input vector by the actor's heading: read the fixed-point angle from
+ * (*(param_2+4))+0x40, look up cos/sin in the shared trig table, build a Y-rotation
+ * matrix, transform the vector in place and copy it to *out. */
+extern void MTX_RotY33_(void *mtx, int cos, int sin);
+extern void MTX_MultVec33(int *out, void *mtx, int *in);
+extern const short data_0203d210[];
+struct Mtx33_020cca74 { int m[9]; };
+struct Vec3_020cca74 { int x, y, z; };
+void func_ov256_020cd054(int *out, int param_2, int *vec) {
+    struct Mtx33_020cca74 mtx;
+    int v = *(int *)(*(int *)(param_2 + 4) + 0x40);
+    int angle = (int)(((unsigned)(((long long)(int)(unsigned)v * 0x28be60db9391LL
+                 + 0x80000000000LL) >> 0x20) << 4) >> 0x10) >> 4;
+    MTX_RotY33_(&mtx, data_0203d210[angle * 2], data_0203d210[angle * 2 + 1]);
+    MTX_MultVec33(vec, &mtx, vec);
+    *(struct Vec3_020cca74 *)out = *(struct Vec3_020cca74 *)vec;
+}

--- a/src/overlays/ov256/calls/func_ov256_020d108c.c
+++ b/src/overlays/ov256/calls/func_ov256_020d108c.c
@@ -1,0 +1,10 @@
+extern void func_ov256_020d13e0(int target, int param_2);
+/* Raise the "done" flag (+0x39c); when the actor is in state 1, forward to
+ * the sub-target (+0x214) along with the second argument. */
+void func_ov256_020d108c(int obj, int param_2) {
+    *(int *)(obj + 0x39c) = 1;
+    if (*(int *)(obj + 0x50) != 1) {
+        return;
+    }
+    func_ov256_020d13e0(*(int *)(obj + 0x214), param_2);
+}

--- a/src/overlays/ov256/calls/func_ov256_020d1900.c
+++ b/src/overlays/ov256/calls/func_ov256_020d1900.c
@@ -1,0 +1,17 @@
+/* Rotate the input vector by the actor's heading: read the fixed-point angle from
+ * (*(param_2+4))+0x50, look up cos/sin in the shared trig table, build a Y-rotation
+ * matrix, transform the vector in place and copy it to *out. */
+extern void MTX_RotY33_(void *mtx, int cos, int sin);
+extern void MTX_MultVec33(int *out, void *mtx, int *in);
+extern const short data_0203d210[];
+struct Mtx33_020cca74 { int m[9]; };
+struct Vec3_020cca74 { int x, y, z; };
+void func_ov256_020d1900(int *out, int param_2, int *vec) {
+    struct Mtx33_020cca74 mtx;
+    int v = *(int *)(*(int *)(param_2 + 4) + 0x50);
+    int angle = (int)(((unsigned)(((long long)(int)(unsigned)v * 0x28be60db9391LL
+                 + 0x80000000000LL) >> 0x20) << 4) >> 0x10) >> 4;
+    MTX_RotY33_(&mtx, data_0203d210[angle * 2], data_0203d210[angle * 2 + 1]);
+    MTX_MultVec33(vec, &mtx, vec);
+    *(struct Vec3_020cca74 *)out = *(struct Vec3_020cca74 *)vec;
+}


### PR DESCRIPTION
Closes #128.

3 functions in ov256 as matching C:

- `func_ov256_020cd054` (148 bytes)
- `func_ov256_020d108c` (36 bytes)
- `func_ov256_020d1900` (148 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #128
