### PR TITLE
Decompile 1 function in ov257

### DIFF
--- a/config/arm9/overlays/ov257/delinks.txt
+++ b/config/arm9/overlays/ov257/delinks.txt
@@ -16,6 +16,10 @@ src/overlays/ov257/calls/func_ov257_020cc5d0.c:
     complete
     .text       start:0x020cc5d0 end:0x020cc678
 
+src/overlays/ov257/calls/func_ov257_020cc678.c:
+    complete
+    .text       start:0x020cc678 end:0x020cc6b0
+
 libs/nitro/wm/calls/WM_EndKeySharing_0x020cca20.c:
     complete
     .text       start:0x020cca20 end:0x020cca2c

--- a/src/overlays/ov257/calls/func_ov257_020cc678.c
+++ b/src/overlays/ov257/calls/func_ov257_020cc678.c
@@ -1,0 +1,10 @@
+extern void func_ov107_020c9ec8(int v, void *b);
+extern void func_ov107_020c6980(void *a, void *b);
+
+void func_ov257_020cc678(char *self, void *b) {
+    if (*(unsigned short *)(self + 0x1ac) & 2) {
+        b = 0;
+    }
+    func_ov107_020c9ec8(*(int *)(self + 0x3d0), b);
+    func_ov107_020c6980(self, b);
+}


### PR DESCRIPTION
Closes #130.

One function in ov257 as matching C:

- `func_ov257_020cc678` (56 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #130
