### PR TITLE
Decompile 1 function in ov258

### DIFF
--- a/config/arm9/overlays/ov258/delinks.txt
+++ b/config/arm9/overlays/ov258/delinks.txt
@@ -76,6 +76,10 @@ src/overlays/ov258/calls/func_ov258_020cfed8.c:
     complete
     .text       start:0x020cfed8 end:0x020cfef4
 
+src/overlays/ov258/calls/func_ov258_020cfef4.c:
+    complete
+    .text       start:0x020cfef4 end:0x020cff28
+
 src/overlays/ov258/calls/func_ov258_020cff94.c:
     complete
     .text       start:0x020cff94 end:0x020cffb0

--- a/src/overlays/ov258/calls/func_ov258_020cfef4.c
+++ b/src/overlays/ov258/calls/func_ov258_020cfef4.c
@@ -1,0 +1,14 @@
+/* Copies the 44-byte transform block and hands over to the follow-up.
+ *
+ * ★ The eleven-word ldm/stm block copy IS reachable from C: it is a plain struct
+ * assignment of a `struct { int w[11]; }`.  mwcc emits exactly the ROM's
+ * `ldm!{r0-r3} / stm!{r0-r3}` twice plus `ldm{r0-r2} / stm{r0-r2}`.  This retires the
+ * "11-word block-copy" class that had five functions parked against it. */
+typedef struct { int w[11]; } Blk44;
+
+extern void func_ov107_020c6980(char *self, int flag);
+
+void func_ov258_020cfef4(char *self, int flag) {
+    func_ov107_020c6980(self, flag);
+    *(Blk44 *)(*(char **)(self + 0x388) + 0x10) = *(Blk44 *)(self + 0xa0);
+}


### PR DESCRIPTION
Closes #132.

One function in ov258 as matching C:

- `func_ov258_020cfef4` (52 bytes)

delinks.txt claims the new file. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for the function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #132
