### PR TITLE
Decompile 3 functions in ov259

### DIFF
--- a/config/arm9/overlays/ov259/delinks.txt
+++ b/config/arm9/overlays/ov259/delinks.txt
@@ -16,6 +16,14 @@ src/overlays/ov259/calls/func_ov259_020cc508.c:
     complete
     .text       start:0x020cc508 end:0x020cc590
 
+src/overlays/ov259/calls/func_ov259_020cc610.c:
+    complete
+    .text       start:0x020cc610 end:0x020cc644
+
+src/overlays/ov259/calls/func_ov259_020cc644.c:
+    complete
+    .text       start:0x020cc644 end:0x020cc678
+
 src/overlays/ov259/calls/func_ov259_020ccde8.c:
     complete
     .text       start:0x020ccde8 end:0x020cce44
@@ -95,6 +103,10 @@ src/overlays/ov259/calls/func_ov259_020cfe0c.c:
 src/overlays/ov259/calls/func_ov259_020d16d4.c:
     complete
     .text       start:0x020d16d4 end:0x020d1700
+
+src/overlays/ov259/calls/func_ov259_020d17fc.c:
+    complete
+    .text       start:0x020d17fc end:0x020d1838
 
 src/overlays/ov259/auto/func_ov259_020d1838.c:
     complete

--- a/src/overlays/ov259/calls/func_ov259_020cc610.c
+++ b/src/overlays/ov259/calls/func_ov259_020cc610.c
@@ -1,0 +1,10 @@
+/* func_ov259_020cc610 -- hand both sub-objects (+0x384, +0x388) to the visitor and then run the
+ * base pass. The visitor takes (arg, object), not the other way round. */
+extern void func_ov107_020c2b20(int arg, int obj);
+extern void func_ov107_020c7b70(int obj, int arg);
+
+void func_ov259_020cc610(int obj, int arg) {
+    func_ov107_020c2b20(arg, *(int *)(obj + 0x384));
+    func_ov107_020c2b20(arg, *(int *)(obj + 0x388));
+    func_ov107_020c7b70(obj, arg);
+}

--- a/src/overlays/ov259/calls/func_ov259_020cc644.c
+++ b/src/overlays/ov259/calls/func_ov259_020cc644.c
@@ -1,0 +1,10 @@
+/* func_ov259_020cc644 -- hand both sub-objects (+0x384, +0x388) to the visitor and then run the
+ * base pass. The visitor takes (arg, object), not the other way round. */
+extern void func_ov107_020c2b38(int arg, int obj);
+extern void func_ov107_020c7c1c(int obj, int arg);
+
+void func_ov259_020cc644(int obj, int arg) {
+    func_ov107_020c2b38(arg, *(int *)(obj + 0x384));
+    func_ov107_020c2b38(arg, *(int *)(obj + 0x388));
+    func_ov107_020c7c1c(obj, arg);
+}

--- a/src/overlays/ov259/calls/func_ov259_020d17fc.c
+++ b/src/overlays/ov259/calls/func_ov259_020d17fc.c
@@ -1,0 +1,10 @@
+extern void func_ov259_020d1c44(int param_1);
+
+void func_ov259_020d17fc(int this_) {
+    if (*(int *)(this_ + 0x50) == 1) {
+        unsigned short *p = (unsigned short *)(this_ + 0x60);
+        unsigned int h = *p;
+        *p = h & ~0xff00 | (((((unsigned int)h << 0x10) >> 0x18 | 2) << 0x18) >> 0x10);
+        func_ov259_020d1c44(*(int *)(this_ + 0x214));
+    }
+}


### PR DESCRIPTION
Closes #134.

3 functions in ov259 as matching C:

- `func_ov259_020cc610` (52 bytes)
- `func_ov259_020cc644` (52 bytes)
- `func_ov259_020d17fc` (60 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #134
