### PR TITLE
Decompile 2 functions in ov260

### DIFF
--- a/config/arm9/overlays/ov260/delinks.txt
+++ b/config/arm9/overlays/ov260/delinks.txt
@@ -104,6 +104,10 @@ src/overlays/ov260/calls/func_ov260_020d1824.c:
     complete
     .text       start:0x020d1824 end:0x020d1858
 
+src/overlays/ov260/calls/func_ov260_020d1a28.c:
+    complete
+    .text       start:0x020d1a28 end:0x020d1a60
+
 src/overlays/ov260/calls/func_ov260_020d1a60.c:
     complete
     .text       start:0x020d1a60 end:0x020d1a98
@@ -119,6 +123,10 @@ src/overlays/ov260/calls/func_ov260_020d1c68.c:
 src/overlays/ov260/calls/func_ov260_020d1d10.c:
     complete
     .text       start:0x020d1d10 end:0x020d1d88
+
+src/overlays/ov260/calls/func_ov260_020d1d88.c:
+    complete
+    .text       start:0x020d1d88 end:0x020d1dc8
 
 src/overlays/ov260/calls/func_ov260_020d1e78.c:
     complete

--- a/src/overlays/ov260/calls/func_ov260_020d1a28.c
+++ b/src/overlays/ov260/calls/func_ov260_020d1a28.c
@@ -1,0 +1,16 @@
+extern int func_0203c7e8();
+extern int func_ov107_020c68ec();
+
+struct S {
+    char pad[0x390];
+    int arr[2][2];
+};
+
+int func_ov260_020d1a28(struct S *r5) {
+    int i;
+    func_0203c7e8(*(int *)((char *)r5 + 0x384));
+    for (i = 0; i < 2; i++) {
+        func_0203c7e8(r5->arr[i][0]);
+    }
+    return func_ov107_020c68ec(r5);
+}

--- a/src/overlays/ov260/calls/func_ov260_020d1d88.c
+++ b/src/overlays/ov260/calls/func_ov260_020d1d88.c
@@ -1,0 +1,13 @@
+struct w3 { int a, b, c; };
+extern int func_0203c9d0(int dst, int src);
+extern const struct w3 data_02041dc8;
+
+void func_ov260_020d1d88(int param_1) {
+    int child = *(int *)(param_1 + 4);
+    func_0203c9d0(*(int *)child + 0xa0, child + 8);
+    {
+        struct w3 *p = (struct w3 *)(child + 0x28);
+        *(struct w3 *)(*(int *)child + 0xf0) = *p;
+        *p = data_02041dc8;
+    }
+}


### PR DESCRIPTION
Closes #136.

2 functions in ov260 as matching C:

- `func_ov260_020d1a28` (56 bytes)
- `func_ov260_020d1d88` (64 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #136
