### PR TITLE
Decompile 4 functions in ov282

### DIFF
--- a/config/arm9/overlays/ov282/delinks.txt
+++ b/config/arm9/overlays/ov282/delinks.txt
@@ -52,6 +52,10 @@ src/overlays/ov282/calls/func_ov282_020d07dc.c:
     complete
     .text       start:0x020d07dc end:0x020d0a54
 
+src/overlays/ov282/calls/func_ov282_020d0a54.c:
+    complete
+    .text       start:0x020d0a54 end:0x020d0b54
+
 src/overlays/ov282/calls/func_ov282_020d0b54.c:
     complete
     .text       start:0x020d0b54 end:0x020d0bbc
@@ -84,6 +88,10 @@ src/overlays/ov282/calls/func_ov282_020d10f4.c:
     complete
     .text       start:0x020d10f4 end:0x020d1158
 
+src/overlays/ov282/calls/func_ov282_020d1468.c:
+    complete
+    .text       start:0x020d1468 end:0x020d1594
+
 src/overlays/ov282/calls/func_ov282_020d1594.c:
     complete
     .text       start:0x020d1594 end:0x020d163c
@@ -111,6 +119,10 @@ src/overlays/ov282/calls/func_ov282_020d1fe4.c:
 src/overlays/ov282/calls/func_ov282_020d2018.c:
     complete
     .text       start:0x020d2018 end:0x020d204c
+
+src/overlays/ov282/calls/func_ov282_020d2244.c:
+    complete
+    .text       start:0x020d2244 end:0x020d2350
 
 src/overlays/ov282/calls/func_ov282_020d2600.c:
     complete
@@ -195,6 +207,10 @@ src/overlays/ov282/calls/func_ov282_020d32b4.c:
 src/overlays/ov282/calls/func_ov282_020d38c8.c:
     complete
     .text       start:0x020d38c8 end:0x020d3990
+
+src/overlays/ov282/calls/func_ov282_020d3b38.c:
+    complete
+    .text       start:0x020d3b38 end:0x020d3c64
 
 src/overlays/ov282/calls/func_ov282_020d3c64.c:
     complete

--- a/src/overlays/ov282/calls/func_ov282_020d0a54.c
+++ b/src/overlays/ov282/calls/func_ov282_020d0a54.c
@@ -1,0 +1,39 @@
+typedef struct { int x, y, z; } Vec3;
+struct T { int a, b, c, d; };
+struct S { struct T t; char pad[0x28 - 16]; unsigned char flag; };
+
+extern int func_0203d040(int cur, int target, int step, int flag);
+extern void func_0202f188(int *out, int *axis, int angle);
+extern void func_0202ed60(void *dst, void *axis, int src);
+extern void func_0202ef54(void *a, void *b, void *c);
+extern int func_0203c9d0(struct S *dst, struct S *src);
+extern int VEC_Mag(const Vec3 *v);
+extern int func_01ff8d18(const Vec3 *source, Vec3 *destination);
+extern void func_01ffa724(int factor, int *src, int *dst);
+extern void INITi_CpuClear32_0x01ff86fc(int value, void *dst, int size);
+extern int data_02042264[3];
+
+void func_ov282_020d0a54(int *self) {
+    int *state = (int *)self[1];
+    int quat[4];
+    struct T tmp;
+    int newAngle;
+    Vec3 *v;
+
+    newAngle = func_0203d040(state[9], state[0xa],
+        (int)((((long long)*(int *)(self[0] + 0x2c) * state[0x14]) + 0x800) >> 12), 0);
+    func_0202f188(quat, data_02042264, state[9] = newAngle);
+    func_0202ed60(&tmp, data_02042264, *state + 0x124);
+    func_0202ef54(&tmp, &tmp, quat);
+    func_0203c9d0((struct S *)(*state + 0xa0), (struct S *)&tmp);
+    if (VEC_Mag((Vec3 *)(state + 5)) > 0x2000) {
+        func_01ff8d18((Vec3 *)(state + 5), (Vec3 *)(state + 5));
+        func_01ffa724(0x2000, (int *)(state + 5), (int *)(state + 5));
+    }
+    v = (Vec3 *)(state + 5);
+    *(Vec3 *)(*state + 0xf0) = *v;
+    INITi_CpuClear32_0x01ff86fc(0, v, 0xc);
+    if (state[0x1b] > 0) {
+        state[0x1b] -= *(int *)(self[0] + 0x2c);
+    }
+}

--- a/src/overlays/ov282/calls/func_ov282_020d1468.c
+++ b/src/overlays/ov282/calls/func_ov282_020d1468.c
@@ -1,0 +1,35 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern int func_ov107_020c5af8(int a, int b, int c, int d);
+extern long long func_01ff8a14(int num, int denom);
+extern void func_ov107_020c5c54(int obj, void *v);
+extern void func_0203c634(int self, int idx, int cb);
+
+void func_ov282_020d1468(int *self) {
+    int *state = (int *)self[1];
+    long long q;
+    Vec3 v;
+
+    if (*(unsigned char *)((char *)state + 0x66) == 0) {
+        state[0x18] += *(int *)(*self + 0x2c);
+        if (state[0x18] >= 0x999) {
+            *(unsigned char *)((char *)state + 0x66) = 1;
+            func_ov107_020c5af8(state[0], 0x16a, 4, state[1]);
+        }
+    }
+    state[0xb] += *(int *)(*self + 0x2c);
+    if (state[0xb] > 0xaaa) {
+        state[0xc] += *(int *)(*self + 0x2c);
+        q = func_01ff8a14(state[0xc], 0x888);
+        if (q > 0x100000000LL) {
+            q = 0x100000000LL;
+        }
+        v = *(Vec3 *)(state + 0xd);
+        v.y -= (int)(((q * (long long)0x6000) + 0x80000000LL) >> 32);
+        func_ov107_020c5c54(state[0], &v);
+    }
+    if (*(unsigned char *)state[3] == 0) {
+        *(char *)(state[0] + 0x1c7) = 6;
+        func_0203c634((int)self, *(signed char *)((int)self + 0x20), 0);
+    }
+}

--- a/src/overlays/ov282/calls/func_ov282_020d2244.c
+++ b/src/overlays/ov282/calls/func_ov282_020d2244.c
@@ -1,0 +1,35 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern void func_ov282_020d4010(int a, int b, int c);
+extern long long func_01ff8a14(int num, int denom);
+extern void func_ov107_020c5c54(int obj, void *v);
+extern void func_0203c634(int self, int idx, int cb);
+extern void func_ov282_020d2350(void);
+
+void func_ov282_020d2244(int *self) {
+    int *state = (int *)self[1];
+    int leaderVal;
+    long long q;
+    int delta;
+    Vec3 v;
+
+    if (*(unsigned char *)((char *)state + 0x64) == 0) {
+        leaderVal = *(int *)(*(int *)(*(int *)(*state + 0x3d4)) + 0x194);
+        func_ov282_020d4010(leaderVal, 0, 0);
+        *(unsigned char *)((char *)state + 0x64) = 1;
+    }
+    state[0xb] += *(int *)(self[0] + 0x2c);
+    state[0xc] += *(int *)(self[0] + 0x2c);
+    q = func_01ff8a14(state[0xc], 0x555);
+    if (q > 0x100000000LL) {
+        q = 0x100000000LL;
+    }
+    delta = (int)(((q * (long long)0x1666) + 0x80000000LL) >> 32);
+    v = *(Vec3 *)(state + 0xd);
+    v.y = v.y + (delta - 0x1000);
+    func_ov107_020c5c54(state[0], &v);
+    if (q == 0x100000000LL) {
+        state[0xb] = 0;
+        func_0203c634((int)self, *(signed char *)((int)self + 0x20), (int)func_ov282_020d2350);
+    }
+}

--- a/src/overlays/ov282/calls/func_ov282_020d3b38.c
+++ b/src/overlays/ov282/calls/func_ov282_020d3b38.c
@@ -1,0 +1,35 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern int func_ov107_020c5af8(int a, int b, int c, int d);
+extern long long func_01ff8a14(int num, int denom);
+extern void func_ov107_020c5c54(int obj, void *v);
+extern void func_0203c634(int self, int idx, int cb);
+
+void func_ov282_020d3b38(int *self) {
+    int *state = (int *)self[1];
+    long long q;
+    Vec3 v;
+
+    if (*(unsigned char *)((char *)state + 0x66) == 0) {
+        state[0x18] += *(int *)(*self + 0x2c);
+        if (state[0x18] >= 0x999) {
+            *(unsigned char *)((char *)state + 0x66) = 1;
+            func_ov107_020c5af8(state[0], 0x16a, 4, state[1]);
+        }
+    }
+    state[0xb] += *(int *)(*self + 0x2c);
+    if (state[0xb] > 0xaaa) {
+        state[0xc] += *(int *)(*self + 0x2c);
+        q = func_01ff8a14(state[0xc], 0x888);
+        if (q > 0x100000000LL) {
+            q = 0x100000000LL;
+        }
+        v = *(Vec3 *)(state + 0xd);
+        v.y -= (int)(((q * (long long)0x6000) + 0x80000000LL) >> 32);
+        func_ov107_020c5c54(state[0], &v);
+    }
+    if (*(unsigned char *)state[3] == 0) {
+        *(char *)(state[0] + 0x1c7) = 0x12;
+        func_0203c634((int)self, *(signed char *)((int)self + 0x20), 0);
+    }
+}


### PR DESCRIPTION
Closes #142.

4 functions in ov282 as matching C:

- `func_ov282_020d0a54` (256 bytes)
- `func_ov282_020d1468` (300 bytes)
- `func_ov282_020d2244` (268 bytes)
- `func_ov282_020d3b38` (300 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #142
