### PR TITLE
Decompile 18 functions in ov283

### DIFF
--- a/config/arm9/overlays/ov283/delinks.txt
+++ b/config/arm9/overlays/ov283/delinks.txt
@@ -12,9 +12,21 @@ src/overlays/ov283/calls/func_ov283_020cbf38.c:
     complete
     .text       start:0x020cbf38 end:0x020cbfc8
 
+src/overlays/ov283/calls/func_ov283_020cc224.c:
+    complete
+    .text       start:0x020cc224 end:0x020cc25c
+
 src/overlays/ov283/calls/func_ov283_020cc25c.c:
     complete
     .text       start:0x020cc25c end:0x020cc2bc
+
+src/overlays/ov283/calls/func_ov283_020cc2bc.c:
+    complete
+    .text       start:0x020cc2bc end:0x020cc318
+
+src/overlays/ov283/calls/func_ov283_020cc318.c:
+    complete
+    .text       start:0x020cc318 end:0x020cc374
 
 src/overlays/ov283/calls/func_ov283_020cc374.c:
     complete
@@ -32,6 +44,18 @@ src/overlays/ov283/calls/func_ov283_020cc830.c:
     complete
     .text       start:0x020cc830 end:0x020cc92c
 
+src/overlays/ov283/calls/func_ov283_020cc92c.c:
+    complete
+    .text       start:0x020cc92c end:0x020cc9e0
+
+src/overlays/ov283/calls/func_ov283_020ccb48.c:
+    complete
+    .text       start:0x020ccb48 end:0x020ccbe0
+
+src/overlays/ov283/calls/func_ov283_020ccca8.c:
+    complete
+    .text       start:0x020ccca8 end:0x020ccd28
+
 src/overlays/ov283/calls/func_ov283_020ccdfc.c:
     complete
     .text       start:0x020ccdfc end:0x020ccfb8
@@ -39,6 +63,14 @@ src/overlays/ov283/calls/func_ov283_020ccdfc.c:
 src/overlays/ov283/calls/func_ov283_020cd108.c:
     complete
     .text       start:0x020cd108 end:0x020cd170
+
+src/overlays/ov283/calls/func_ov283_020cd170.c:
+    complete
+    .text       start:0x020cd170 end:0x020cd200
+
+src/overlays/ov283/calls/func_ov283_020cd200.c:
+    complete
+    .text       start:0x020cd200 end:0x020cd27c
 
 src/overlays/ov283/calls/func_ov283_020cd558.c:
     complete
@@ -48,9 +80,25 @@ src/overlays/ov283/calls/func_ov283_020cd9e0.c:
     complete
     .text       start:0x020cd9e0 end:0x020cda58
 
+src/overlays/ov283/calls/func_ov283_020cda58.c:
+    complete
+    .text       start:0x020cda58 end:0x020cdae4
+
+src/overlays/ov283/calls/func_ov283_020cdae4.c:
+    complete
+    .text       start:0x020cdae4 end:0x020cdb88
+
+src/overlays/ov283/calls/func_ov283_020cdb88.c:
+    complete
+    .text       start:0x020cdb88 end:0x020cdbfc
+
 src/overlays/ov283/calls/func_ov283_020cdeac.c:
     complete
     .text       start:0x020cdeac end:0x020cdf1c
+
+src/overlays/ov283/calls/func_ov283_020ce214.c:
+    complete
+    .text       start:0x020ce214 end:0x020ce2a0
 
 src/overlays/ov283/calls/func_ov283_020ce2a0.c:
     complete
@@ -59,6 +107,14 @@ src/overlays/ov283/calls/func_ov283_020ce2a0.c:
 src/overlays/ov283/calls/func_ov283_020ce2e4.c:
     complete
     .text       start:0x020ce2e4 end:0x020ce328
+
+src/overlays/ov283/calls/func_ov283_020ce620.c:
+    complete
+    .text       start:0x020ce620 end:0x020ce6ac
+
+src/overlays/ov283/calls/func_ov283_020ce6ac.c:
+    complete
+    .text       start:0x020ce6ac end:0x020ce6e0
 
 src/overlays/ov283/calls/func_ov283_020ce6e0.c:
     complete
@@ -100,6 +156,10 @@ src/overlays/ov283/calls/func_ov283_020ceee8.c:
     complete
     .text       start:0x020ceee8 end:0x020cef04
 
+src/overlays/ov283/calls/func_ov283_020cef04.c:
+    complete
+    .text       start:0x020cef04 end:0x020cef38
+
 src/overlays/ov283/auto/func_ov283_020cef38.c:
     complete
     .text       start:0x020cef38 end:0x020cef4c
@@ -115,6 +175,10 @@ src/overlays/ov283/calls/func_ov283_020cef98.c:
 src/overlays/ov283/calls/func_ov283_020cf034.c:
     complete
     .text       start:0x020cf034 end:0x020cf0ac
+
+src/overlays/ov283/calls/func_ov283_020cf0ac.c:
+    complete
+    .text       start:0x020cf0ac end:0x020cf0f0
 
 src/overlays/ov283/calls/func_ov283_020cf0f0.c:
     complete
@@ -136,6 +200,10 @@ src/overlays/ov283/calls/func_ov283_020cf328.c:
     complete
     .text       start:0x020cf328 end:0x020cf34c
 
+src/overlays/ov283/calls/func_ov283_020cf43c.c:
+    complete
+    .text       start:0x020cf43c end:0x020cf488
+
 src/overlays/ov283/calls/func_ov283_020cf488.c:
     complete
     .text       start:0x020cf488 end:0x020cf4d4
@@ -147,6 +215,10 @@ src/overlays/ov283/calls/func_ov283_020cf4d4.c:
 src/overlays/ov283/calls/func_ov283_020cf57c.c:
     complete
     .text       start:0x020cf57c end:0x020cf5f4
+
+src/overlays/ov283/calls/func_ov283_020cf740.c:
+    complete
+    .text       start:0x020cf740 end:0x020cf7d4
 
 src/overlays/ov283/auto/func_ov283_020cf7d4.c:
     complete

--- a/src/overlays/ov283/calls/func_ov283_020cc224.c
+++ b/src/overlays/ov283/calls/func_ov283_020cc224.c
@@ -1,0 +1,16 @@
+extern void func_0203c7e8(int *param_1);
+extern void func_ov107_020c68ec(int param_1);
+
+struct Elem8 {
+    int pad;
+    int *ptr;
+};
+
+void func_ov283_020cc224(int param_1) {
+    int i;
+    for (i = 0; i < 6; i++) {
+        func_0203c7e8(((struct Elem8 *)param_1)[i + 0x7d].ptr);
+    }
+    func_0203c7e8(*(int **)(param_1 + 0x384));
+    func_ov107_020c68ec(param_1);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cc2bc.c
+++ b/src/overlays/ov283/calls/func_ov283_020cc2bc.c
@@ -1,0 +1,11 @@
+extern void func_ov107_020c2b20(int obj, int arg1);
+extern void func_ov107_020c7b70(int obj, int arg1);
+
+void func_ov283_020cc2bc(int *list, int target) {
+    int i;
+    for (i = 0; i < 2; i++)
+        func_ov107_020c2b20(target, list[i + 0xe7]);
+    for (i = 0; i < 16; i++)
+        func_ov107_020c2b20(target, list[i + 0xe9]);
+    func_ov107_020c7b70((int)list, target);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cc318.c
+++ b/src/overlays/ov283/calls/func_ov283_020cc318.c
@@ -1,0 +1,11 @@
+extern void func_ov107_020c2b38(int obj, int arg1);
+extern void func_ov107_020c7c1c(int obj, int arg1);
+
+void func_ov283_020cc318(int *list, int target) {
+    int i;
+    for (i = 0; i < 2; i++)
+        func_ov107_020c2b38(target, list[i + 0xe7]);
+    for (i = 0; i < 16; i++)
+        func_ov107_020c2b38(target, list[i + 0xe9]);
+    func_ov107_020c7c1c((int)list, target);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cc92c.c
+++ b/src/overlays/ov283/calls/func_ov283_020cc92c.c
@@ -1,0 +1,23 @@
+extern int func_ov107_020c5af8();
+
+void func_ov283_020cc92c(int param1, int param2, int param3, int param4)
+{
+    int type;
+
+    if (*(int *)(param1 + 0x3e4) != 0) {
+        switch (param3) {
+        case 0: type = 0; break;
+        case 1: type = 1; break;
+        case 2: type = 2; break;
+        case 3: type = 3; break;
+        case 4: type = 4; break;
+        case 5: type = 5; break;
+        case 6: type = 6; break;
+        case 12: type = 7; break;
+        default: return;
+        }
+        func_ov107_020c5af8(param1, 0x17e, type, param4);
+    } else {
+        func_ov107_020c5af8(param1, 0x173, param3, param4);
+    }
+}

--- a/src/overlays/ov283/calls/func_ov283_020ccb48.c
+++ b/src/overlays/ov283/calls/func_ov283_020ccb48.c
@@ -1,0 +1,67 @@
+extern int func_ov107_020cab14();
+extern void VEC_Subtract(int *a, int *b, int *out);
+extern int func_01ff8d18(int *source, int *destination);
+extern int func_020050b4();
+
+typedef struct { int x, y, z; } Vec3_020ccb48;
+
+typedef struct {
+    char pad0[0x80];
+    int v80;
+    char pad84[0x10c];
+    Vec3_020ccb48 v190;
+} P3bc_020ccb48;
+
+typedef struct {
+    char pad0[0x80];
+    int v80;
+    char pad84[0x2c];
+    Vec3_020ccb48 vb0;
+    char padbc[0x10b];
+    unsigned char b1c7;
+    char pad1c8[0x1c8];
+    P3bc_020ccb48 *p3bc;
+} Obj_020ccb48;
+
+typedef struct {
+    Obj_020ccb48 *obj;
+    char pad4[0x3c];
+    int v40;
+} Wrap_020ccb48;
+
+typedef struct {
+    char pad0[4];
+    Wrap_020ccb48 *wrap;
+} Param_020ccb48;
+
+int func_ov283_020ccb48(Param_020ccb48 *param)
+{
+    Wrap_020ccb48 *wrap;
+    Obj_020ccb48 *obj;
+    P3bc_020ccb48 *p3bc;
+    int diff;
+    Vec3_020ccb48 local;
+
+    wrap = param->wrap;
+    obj = wrap->obj;
+    p3bc = (P3bc_020ccb48 *)func_ov107_020cab14(obj, 0);
+    obj = wrap->obj;
+    obj->p3bc = p3bc;
+    obj = wrap->obj;
+    p3bc = obj->p3bc;
+    if (p3bc == 0) {
+        obj->b1c7 = 2;
+        return -1;
+    }
+
+    VEC_Subtract(&p3bc->v190.x, &obj->vb0.x, &local.x);
+    diff = func_01ff8d18(&local.x, &local.x);
+    obj = wrap->obj;
+    p3bc = obj->p3bc;
+    diff = diff - (p3bc->v80 + obj->v80);
+    if (diff < 0) {
+        diff = 0;
+    }
+    wrap->v40 = func_020050b4(local.x, local.z);
+    return diff;
+}

--- a/src/overlays/ov283/calls/func_ov283_020ccca8.c
+++ b/src/overlays/ov283/calls/func_ov283_020ccca8.c
@@ -1,0 +1,29 @@
+typedef signed int fx32;
+typedef struct { fx32 x, y, z; } VecFx32;
+
+extern void VEC_Subtract(fx32 *a, fx32 *b, fx32 *out);
+extern fx32 func_01ff8d18(const VecFx32 *source, VecFx32 *destination);
+
+int func_ov283_020ccca8(void *self) {
+    char *mover = *(char **)self;
+    char *state = *(char **)((char *)self + 4);
+    int accum = *(int *)(state + 0x64) + *(int *)(mover + 0x2c);
+    *(int *)(state + 0x64) = accum;
+
+    if (accum >= 0x2a8) {
+        char *target = *(char **)state;
+        VecFx32 diff;
+        VEC_Subtract((fx32 *)(state + 0x28), (fx32 *)(target + 0xb0), (fx32 *)&diff);
+
+        fx32 distance = func_01ff8d18(&diff, &diff);
+
+        target = *(char **)state;
+        *(VecFx32 *)(state + 0x28) = *(VecFx32 *)(target + 0xb0);
+        *(int *)(state + 0x64) = 0;
+
+        if (distance < 0x300) {
+            return 0;
+        }
+    }
+    return 1;
+}

--- a/src/overlays/ov283/calls/func_ov283_020cd170.c
+++ b/src/overlays/ov283/calls/func_ov283_020cd170.c
@@ -1,0 +1,28 @@
+extern unsigned int func_02023eb4(unsigned int range);
+extern int func_ov283_020ced80(int param_1, int param_2);
+extern void func_0203c634(int *a, int i, int v);
+
+struct hw60lo_020cd170 { unsigned short lo : 8; unsigned short hi : 8; };
+
+void func_ov283_020cd170(int param_1) {
+    int child = *(int *)(param_1 + 4);
+    int obj = *(int *)child;
+    int base, d, i;
+
+    if ((((struct hw60lo_020cd170 *)(obj + 0x60))->lo & 1) == 0) return;
+
+    base = *(int *)(obj + 0x224);
+    d = *(int *)(obj + 0x228) - base;
+    if (d < 0) d = -d;
+    *(int *)(child + 0x4c) = base + func_02023eb4(d + 1);
+    *(int *)(child + 0x54) = 0;
+
+    for (i = 0; i < 2; i++) {
+        obj = *(int *)child;
+        func_ov283_020ced80(((int *)obj)[i + 0x39c / 4], ((int *)obj)[i + 0x394 / 4]);
+    }
+
+    obj = *(int *)child;
+    *(signed char *)(obj + 0x1c7) = *(signed char *)(obj + 0x1c9);
+    func_0203c634((int *)param_1, *(signed char *)(param_1 + 0x20), 0);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cd200.c
+++ b/src/overlays/ov283/calls/func_ov283_020cd200.c
@@ -1,0 +1,20 @@
+typedef struct { int w[3]; } Blk12;
+
+extern void func_ov107_020c9264(int obj, int tag1, int tag_lsb);
+extern int func_02023eb4(unsigned int mul);
+extern void func_0203c634(void *obj, int idx, void *value);
+extern void func_ov283_020cd27c(void);
+extern Blk12 data_02041dc8;
+
+void func_ov283_020cd200(char *obj) {
+    char *p = *(char **)(obj + 4);
+    func_ov107_020c9264(*(int *)p, 0, 1);
+    *(Blk12 *)(p + 0x10) = data_02041dc8;
+    *(int *)(p + 0x5c) = 0;
+    int min = *(int *)(*(char **)p + 0x224);
+    int range = *(int *)(*(char **)p + 0x228) - min;
+    if (range < 0) range = -range;
+    *(int *)(p + 0x48) = min + func_02023eb4(range + 1);
+    *(int *)(p + 0x78) = 0;
+    func_0203c634(obj, *(signed char *)(obj + 0x20), func_ov283_020cd27c);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cda58.c
+++ b/src/overlays/ov283/calls/func_ov283_020cda58.c
@@ -1,0 +1,26 @@
+struct vec3 { int x, y, z; };
+struct b1 { unsigned char b:1; };
+
+extern void func_01ffa724(int factor, int *src, int *dst);
+extern void func_ov107_020c9264(int obj, int a, int b);
+extern void func_0203c634(int obj, int a, int cb);
+extern void func_ov283_020cdae4(void);
+
+void func_ov283_020cda58(int *this) {
+    int node = this[1];
+    struct vec3 *v = (struct vec3 *)(node + 0x1c);
+    *(struct vec3 *)(node + 0x10) = *v;
+    *(int *)(node + 0x14) = *(int *)(node + 0x58);
+    *(int *)(node + 0x58) = *(int *)(node + 0x58) - 0x80;
+    func_01ffa724(0xe00, (int *)v, (int *)v);
+
+    if (*(unsigned char *)(*(int *)(node + 4) + 0xad) != 0) {
+        int obj = *(int *)node;
+        if (!((struct b1 *)(obj + 0x17a))->b) {
+            return;
+        }
+    }
+
+    func_ov107_020c9264(*(int *)node, 4, 0);
+    func_0203c634((int)this, *(signed char *)((int)this + 0x20), (int)&func_ov283_020cdae4);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cdae4.c
+++ b/src/overlays/ov283/calls/func_ov283_020cdae4.c
@@ -1,0 +1,29 @@
+struct vec3_020cdae4 { int x, y, z; };
+
+extern void func_01ffa724(int factor, int *src, int *dst);
+extern unsigned int func_02023e80(unsigned int range);
+extern void func_0203c634(int *a, int i, int v);
+
+void func_ov283_020cdae4(int *this)
+{
+    int node = this[1];
+    struct vec3_020cdae4 *v = (struct vec3_020cdae4 *)(node + 0x1c);
+    int y;
+
+    *(struct vec3_020cdae4 *)(node + 0x10) = *v;
+    *(int *)(node + 0x14) = *(int *)(node + 0x58);
+    *(int *)(node + 0x58) = *(int *)(node + 0x58) - 0x80;
+    func_01ffa724(0xe00, (int *)v, (int *)v);
+
+    if (*(unsigned char *)(*(int *)(node + 4) + 0xad) != 0) {
+        return;
+    }
+
+    y = func_02023e80(0x1922) + 0x1922;
+    *(int *)(node + 0x34) = y;
+    *(int *)(node + 0x7c) = (y > 0x25b3) ? 1 : 0;
+    *(int *)(node + 0x3c) = 0;
+    *(signed char *)(*(int *)node + 0x1c7) = 4;
+
+    func_0203c634(this, *(signed char *)((char *)this + 0x20), 0);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cdb88.c
+++ b/src/overlays/ov283/calls/func_ov283_020cdb88.c
@@ -1,0 +1,42 @@
+typedef struct { int a, b, c; } Blk12;
+
+typedef struct {
+    int p0;
+    char pad1[4];
+    int f8;
+    char pad2[4];
+    Blk12 blk;
+    char pad3[0x2c];
+    int f48;
+    char pad4[0x1c];
+    int f68;
+    int f6c;
+    char pad5[4];
+    int f74;
+} Ctx;
+
+typedef struct {
+    int field_00;
+    Ctx *ctx;
+} Self;
+
+extern int func_ov283_020cc92c(int, int, int, int);
+extern int func_ov107_020c9264(int, int, int);
+extern void func_0203c634(int *a, int i, int v);
+extern Blk12 data_02041dc8;
+extern void func_ov283_020cdbfc(void);
+
+void func_ov283_020cdb88(Self *self) {
+    Ctx *ctx = self->ctx;
+
+    func_ov283_020cc92c(ctx->p0, 0x173, 7, ctx->f8);
+    func_ov107_020c9264(ctx->p0, 9, 0);
+
+    ctx->f68 = 0;
+    ctx->f6c = 0;
+    ctx->f48 = 0;
+    ctx->blk = data_02041dc8;
+    ctx->f74 = 0;
+
+    func_0203c634((int *)self, *(signed char *)((char *)self + 0x20), (int)func_ov283_020cdbfc);
+}

--- a/src/overlays/ov283/calls/func_ov283_020ce214.c
+++ b/src/overlays/ov283/calls/func_ov283_020ce214.c
@@ -1,0 +1,29 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern void VEC_Subtract(int *a, int *b, int *out);
+extern int func_01ff8d18(const Vec3 *source, Vec3 *destination);
+extern int func_020050b4(int x, int z);
+extern void func_ov107_020c0b90(int owner, int a, Vec3 v, int flag);
+extern void func_0203c634(int self, int idx, void *cb);
+extern void func_ov283_020ce2a0(int);
+
+void func_ov283_020ce214(int *self) {
+    int state = self[1];
+    int q = *(int *)state;
+    Vec3 *a = (Vec3 *)(*(int *)(q + 0x390) + 0x190);
+    Vec3 *b = (Vec3 *)(q + 0x74);
+    Vec3 diff;
+    VEC_Subtract((int *)a, (int *)b, (int *)&diff);
+
+    func_01ff8d18(&diff, &diff);
+
+    int angle = func_020050b4(diff.x, diff.z);
+    *(int *)(state + 0x40) = angle;
+    *(int *)(state + 0x38) = angle;
+
+    Vec3 v = *(Vec3 *)(*(int *)(state + 8));
+    q = *(int *)state;
+    func_ov107_020c0b90(q, 1, v, 0);
+
+    func_0203c634((int)self, *(signed char *)((int)self + 0x20), (void *)&func_ov283_020ce2a0);
+}

--- a/src/overlays/ov283/calls/func_ov283_020ce620.c
+++ b/src/overlays/ov283/calls/func_ov283_020ce620.c
@@ -1,0 +1,29 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern void VEC_Subtract(int *a, int *b, int *out);
+extern int func_01ff8d18(const Vec3 *source, Vec3 *destination);
+extern int func_020050b4(int x, int z);
+extern void func_ov107_020c0b90(int owner, int a, Vec3 v, int flag);
+extern void func_0203c634(int self, int idx, void *cb);
+extern void func_ov283_020ce6ac(int *node);
+
+void func_ov283_020ce620(int *self) {
+    int state = self[1];
+    int q = *(int *)state;
+    Vec3 *a = (Vec3 *)(*(int *)(q + 0x390) + 0x190);
+    Vec3 *b = (Vec3 *)(q + 0x74);
+    Vec3 diff;
+    VEC_Subtract((int *)a, (int *)b, (int *)&diff);
+
+    func_01ff8d18(&diff, &diff);
+
+    int angle = func_020050b4(diff.x, diff.z);
+    *(int *)(state + 0x40) = angle;
+    *(int *)(state + 0x38) = angle;
+
+    Vec3 v = *(Vec3 *)(*(int *)(state + 8));
+    q = *(int *)state;
+    func_ov107_020c0b90(q, 1, v, 0);
+
+    func_0203c634((int)self, *(signed char *)((int)self + 0x20), (void *)&func_ov283_020ce6ac);
+}

--- a/src/overlays/ov283/calls/func_ov283_020ce6ac.c
+++ b/src/overlays/ov283/calls/func_ov283_020ce6ac.c
@@ -1,0 +1,25 @@
+/* Reset the state's timer at +0x50 and pick the next sub-state for the owner: a 30%-or-less
+ * roll (0..100) picks action 10, otherwise action 7, written to the owner's action byte at
+ * +0x1c7.
+ *
+ * The roll goes through the inlined RandRange(lo, hi) wrapper that ov114's callers spell out
+ * by hand (`lo + func_02023eb4(|hi - lo| + 1)`). With lo == 0 the inliner leaves `0 + roll`
+ * behind, which is the ROM's bare `add r0, r0, #0` between the call and the compare. */
+extern unsigned int func_02023eb4(unsigned int range);
+
+static inline int RandRange(int lo, int hi)
+{
+    int span = hi - lo;
+
+    if (span < 0)
+        span = -span;
+    return lo + func_02023eb4(span + 1);
+}
+
+void func_ov283_020ce6ac(int *node)
+{
+    int *state = (int *)node[1];
+
+    *(int *)((char *)state + 0x50) = 0;
+    *(char *)(*state + 0x1c7) = (RandRange(0, 100) > 30) ? 7 : 10;
+}

--- a/src/overlays/ov283/calls/func_ov283_020cef04.c
+++ b/src/overlays/ov283/calls/func_ov283_020cef04.c
@@ -1,0 +1,14 @@
+/* Copies the 44-byte transform block and hands over to the follow-up.
+ *
+ * ★ The eleven-word ldm/stm block copy IS reachable from C: it is a plain struct
+ * assignment of a `struct { int w[11]; }`.  mwcc emits exactly the ROM's
+ * `ldm!{r0-r3} / stm!{r0-r3}` twice plus `ldm{r0-r2} / stm{r0-r2}`.  This retires the
+ * "11-word block-copy" class that had five functions parked against it. */
+typedef struct { int w[11]; } Blk44;
+
+extern void func_ov107_020c6980(char *self, int flag);
+
+void func_ov283_020cef04(char *self, int flag) {
+    func_ov107_020c6980(self, flag);
+    *(Blk44 *)(*(char **)(self + 0x38c) + 0x10) = *(Blk44 *)(self + 0xa0);
+}

--- a/src/overlays/ov283/calls/func_ov283_020cf0ac.c
+++ b/src/overlays/ov283/calls/func_ov283_020cf0ac.c
@@ -1,0 +1,31 @@
+typedef signed char s8;
+
+typedef struct { int a, b, c, d; } T4;
+typedef struct { T4 t; char pad[0x28 - 16]; unsigned char flag; } S;
+
+typedef struct {
+    void *f0;
+    void *f1;
+} Ctx;
+
+typedef struct {
+    void *field_00;
+    Ctx *ctx;
+} Self;
+
+extern void func_ov107_020c5c54(char *node, void *pos);
+extern int func_0203c9d0(S *dst, S *src);
+
+void func_ov283_020cf0ac(Self *self) {
+    Ctx *ctx = self->ctx;
+
+    if (*(s8 *)((char *)ctx->f0 + 0x1c6) != 1) {
+        return;
+    }
+    if (ctx->f1 == 0) {
+        return;
+    }
+
+    func_ov107_020c5c54((char *)ctx->f0, (char *)ctx->f1 + 0x14);
+    func_0203c9d0((S *)((char *)ctx->f0 + 0xa0), (S *)((char *)ctx->f1 + 4));
+}

--- a/src/overlays/ov283/calls/func_ov283_020cf43c.c
+++ b/src/overlays/ov283/calls/func_ov283_020cf43c.c
@@ -1,0 +1,25 @@
+typedef struct {
+    void *p0;
+    int *vecB;
+    char pad[0x14 - 8];
+    int field_14;
+    int field_18;
+} A;
+
+extern void VEC_Subtract(int *a, int *b, int *out);
+extern int func_020050b4(int x, int z);
+
+void func_ov283_020cf43c(A *a, void *b) {
+    void *p1 = a->p0;
+    void *p2 = *(void **)((char *)p1 + 0x38c);
+    void *p3 = *(void **)((char *)p2 + 0x390);
+    int *vecA = (int *)((char *)p3 + 0x190);
+    int out[3];
+    int angle;
+
+    VEC_Subtract(vecA, a->vecB, out);
+    angle = func_020050b4(out[0], out[2]);
+    a->field_18 = angle;
+    a->field_14 = angle;
+    *(unsigned char *)((char *)a->p0 + 0x1c7) = 1;
+}

--- a/src/overlays/ov283/calls/func_ov283_020cf740.c
+++ b/src/overlays/ov283/calls/func_ov283_020cf740.c
@@ -1,0 +1,24 @@
+struct Vec3_020cf740 { int x, y, z; };
+extern const struct Vec3_020cf740 data_02041dc8;
+extern void func_0203c634(int *a, int i, int v);
+extern void func_ov283_020cf7d4(void);
+
+struct node60_020cf740 { unsigned short lo : 8; unsigned short hi : 8; };
+
+void func_ov283_020cf740(int param_1) {
+    int child = *(int *)(param_1 + 4);
+
+    *(int *)(*(int *)child + 0x388) = 0;
+
+    {
+        unsigned short *p = (unsigned short *)(*(int *)child + 0x60);
+        unsigned int hi = ((unsigned int)*p << 0x10) >> 0x18;
+        hi |= 0x80;
+        *p = (unsigned short)((*p & ~0xff00) | ((hi << 0x18) >> 16));
+    }
+    ((struct node60_020cf740 *)(*(int *)child + 0x60))->hi &= ~1;
+
+    *(struct Vec3_020cf740 *)(child + 8) = data_02041dc8;
+
+    func_0203c634((int *)param_1, *(signed char *)(param_1 + 0x20), (int)&func_ov283_020cf7d4);
+}


### PR DESCRIPTION
Closes #144.

18 functions in ov283 as matching C:

- `func_ov283_020cc224` (56 bytes)
- `func_ov283_020cc2bc` (92 bytes)
- `func_ov283_020cc318` (92 bytes)
- `func_ov283_020cc92c` (180 bytes)
- `func_ov283_020ccb48` (152 bytes)
- `func_ov283_020ccca8` (128 bytes)
- `func_ov283_020cd170` (144 bytes)
- `func_ov283_020cd200` (124 bytes)
- `func_ov283_020cda58` (140 bytes)
- `func_ov283_020cdae4` (164 bytes)
- `func_ov283_020cdb88` (116 bytes)
- `func_ov283_020ce214` (140 bytes)
- `func_ov283_020ce620` (140 bytes)
- `func_ov283_020ce6ac` (52 bytes)
- `func_ov283_020cef04` (52 bytes)
- `func_ov283_020cf0ac` (68 bytes)
- `func_ov283_020cf43c` (76 bytes)
- `func_ov283_020cf740` (148 bytes)

delinks.txt claims the new files. Nothing else in the module config changes.

## Verification

- `tools/verify_idx.py` reports `>>> MATCH <<<` for every function listed.
- My fork is this repository's main plus the changes in my open PRs. A full link there (`ninja build/arm9.elf`, then `dsd check modules`) gives 306 of 306 modules identical to the ROM.
- `tools/audit_symbol_names.py` reports no file whose symbol differs from its name.

## Checklist

- [x] Every function compiles to byte-exact output (`>>> MATCH <<<`, checked with `tools/verify_idx.py`)
- [x] Only C source is added, no ROM, assets, compiler, or binaries
- [x] Claimed in #144
